### PR TITLE
Add Google Ads attribution tracking for offline conversions

### DIFF
--- a/docs/ads/google-ads-campaign-plan-kit.md
+++ b/docs/ads/google-ads-campaign-plan-kit.md
@@ -1,0 +1,422 @@
+# Google Ads Campaign Plan — Kit Pinta Barriguitas
+
+**Versión:** 2.0 (budget-adjusted para 300k COP)
+**Fecha:** 2026-04-10
+**Landing:** https://www.croko.co/kit-pinta-barriguitas
+**Checkout:** https://checkout.wompi.co/l/tIZLKf
+**Scorecard de decisión:** [google-ads-day21-scorecard.md](./google-ads-day21-scorecard.md)
+
+---
+
+## 1. Product Brief (confirmado del source)
+
+| Field | Value |
+|---|---|
+| Product | Kit Pinta Barriguitas (belly painting kit) |
+| Price | **$190.000 COP** (~$46 USD) |
+| Shipping | Free, 3–7 días, toda Colombia |
+| Returns | 30 días |
+| SKU | CROKO-KPB-001 |
+| Brand | Croko |
+| USPs | 15 pinturas hipoalergénicas · 4 pinceles profesionales · 3 plantillas transferibles · videotutoriales · +500 familias · 4.8★ (200 reseñas) |
+| Audiencia primaria | Embarazadas 3er trimestre (semanas 28-36) |
+| Audiencia secundaria | Compradores de regalo de baby shower (amigas, familia, pareja) |
+| Use cases | Baby shower, gender reveal, sesión de fotos de maternidad, momento familiar pre-parto |
+
+---
+
+## 2. Restricciones del proyecto (contexto crítico)
+
+1. **Presupuesto inicial:** $300.000 COP/mes ($10k/día, ~$75 USD/mes) — very tight
+2. **Tracking gap:** Wompi es checkout externo. No todos los usuarios regresan a `/gracias`. Muchos cierran venta por WhatsApp sin pasar por Wompi.
+3. **Geo:** Medellín, Cali, Bogotá (foco urbano)
+4. **Indexación:** croko.co tiene 1 de 12 páginas indexadas (post-migración desde maquillajeembarazadas.com). Dominio con baja autoridad. Ver `INDEXATION-STATUS.md`.
+5. **n8n existente:** ya corriendo para otros workflows (Formspree replacement) — reutilizable para offline conversion import.
+
+---
+
+## 3. Tracking híbrido — 5 capas (RESUELVE EL GAP)
+
+Tu problema: usuarios no siempre vuelven a `/gracias`, muchos cierran por WhatsApp. Solución: **5 capas independientes, cada una captura un tipo de comprador**.
+
+### Capa 1 — Hard Conversion (web return flow)
+
+- **Evento:** `purchase`, valor = 190.000 COP
+- **Dónde:** `www.croko.co/gracias`
+- **Cómo:** Reusar el script de `wompi-tracking-technical-guide.md`, cambiar dominio de `maquillajeembarazadas.com` → `croko.co`, actualizar Wompi redirect
+- **Cubre:** ~40-50% de compradores (los que regresan del checkout)
+
+### Capa 2 — Click-to-Wompi (begin_checkout) [CRÍTICO]
+
+- **Evento:** `begin_checkout`, valor estimado = 28.500 COP (190k × 15% est. checkout→purchase rate)
+- **Dónde:** cada clic al botón "Comprar" en desktop, mobile, sticky CTA, header
+- **Cómo:** disparar `gtag('event','begin_checkout',{value:28500,currency:'COP',items:[...]})` antes de abrir Wompi
+- **Cubre:** **100% de intención de compra real** — señal principal de optimización en meses 1-2
+
+### Capa 3 — WhatsApp Click (generate_lead)
+
+- **Evento:** `generate_lead`, valor estimado = 47.500 COP (190k × 25% est. WA→purchase rate)
+- **Dónde:** cada clic a `wa.me/...` en la página
+- **Cómo:** gtag en onClick del botón WhatsApp
+- **Cubre:** los que cierran por chat
+
+### Capa 4 — GCLID Capture + Offline Conversion Import (ventas por WhatsApp)
+
+**Esto cierra el círculo para ventas cerradas por WhatsApp.**
+
+```
+Paso 1 [frontend]: en croko.co landing, capturar ?gclid= → localStorage (90 días)
+Paso 2 [frontend]: al abrir WhatsApp, inyectar al mensaje:
+        "Hola! Quiero el Kit Pinta Barriguitas. Ref: GCLID_xxxxxx"
+Paso 3 [n8n]: cuando se confirma venta manualmente en Frappe CRM,
+        extraer gclid del mensaje o de Wompi reference
+Paso 4 [n8n]: POST a Google Ads API → Offline Conversion Import
+        https://developers.google.com/google-ads/api/docs/conversions/upload-clicks
+Paso 5: conversión atribuida al anuncio original, Google aprende
+```
+
+**Ventaja:** n8n ya está corriendo en tu infraestructura — este workflow encaja.
+
+### Capa 5 — Enhanced Conversions for Leads
+
+- Activar en Google Ads → enviar email/teléfono hasheado desde Wompi return o desde el form de WhatsApp
+- Mejora atribución +5–15% en promedio
+
+### Conversion setup en Google Ads
+
+| Conversion | Count | Category | Primary? | Value |
+|---|---|---|---|---|
+| `purchase` (web) | One | Purchase | ✅ Yes | 190.000 |
+| `purchase_offline` (Wompi+WA via n8n) | One | Purchase | ✅ Yes | 190.000 (real) |
+| `begin_checkout` | One | Begin Checkout | ❌ Secondary | 28.500 |
+| `generate_lead` (WA click) | Every | Contact | ❌ Secondary | 47.500 |
+
+> **Regla crítica:** Solo las 2 de `purchase` cuentan como "Primary" (Google Ads optimiza contra ellas). Las otras 2 son "Observed/Secondary" — señales para ti, no para el algoritmo. Esto evita que Google infla bids por clics baratos a WhatsApp.
+
+---
+
+## 4. Campaign Architecture v2 (ajustada a $300k/mes)
+
+### Campaña única: "Kit Pinta Barriguitas - CO - Search"
+
+**Tipo:** Search
+**Bidding:** Manual CPC (max $2.000 COP) → Max Conversions cuando alcances 15+ conv/mes
+**Daily budget:** $10.000 COP
+**Geo:** Medellín + Cali + Bogotá, radio 25 km, "People in or regularly in your targeted locations"
+**Idioma:** Español
+**Device bid adjustments:** Mobile +20%, Desktop -20% (mientras no se arregle el CTA desktop roto)
+**Schedule:** Lun-Dom 06:00-23:00, pausar 23:00-06:00
+**Attribution:** Data-driven, 30-day click / 1-day view
+
+### Ad Group 1A — Product Direct (100% del budget mes 1)
+
+Keywords (exact + phrase match, NO broad):
+
+```
+[kit pinta barriguitas]
+"kit pinta barriguitas"
+[kit pintura barriga embarazada]
+"pintar barriga embarazada"
+"pintura para barriga de embarazada"
+[belly painting colombia]
+"belly painting kit"
+"kit belly painting"
+"maquillaje prenatal"
+"pintura hipoalergenica embarazada"
+"belly art embarazo"
+```
+
+### Ad Group 1B — Baby Shower Activity (activar mes 2 solo si 1A valida)
+
+```
+"actividades baby shower originales"
+"juegos para baby shower"
+"ideas baby shower diferentes"
+"que hacer en un baby shower"
+```
+
+### Ad Groups que NO corren en Fase 1
+
+- ❌ **Gift Intent** ("regalo baby shower", "que regalar embarazada") — CPC alto, intent más ancho, no rentable con $300k/mes
+- ❌ **Performance Max** — indexación débil + budget insuficiente
+- ❌ **Demand Gen** — requiere volumen y autoridad de dominio
+- ❌ **Dynamic Search Ads** — requiere páginas indexadas
+
+### Negative keywords globales (crear shared list)
+
+```
+gratis, descargar, pdf, tutorial gratis, diy, casero, casera, hazlo tu mismo,
+niños, infantil, fiesta infantil, cumpleaños, disfraz, halloween,
+tatuaje, henna, mandala tatuaje, oleo, acrilico, lienzo,
+trabajo, empleo, curso, instituto, academia, profesional
+```
+
+---
+
+## 5. Ad Copy — RSA (Spanish, Colombia)
+
+### Headlines (máx 30 chars c/u)
+
+**Evergreen (15 rotativos):**
+
+1. Kit Pinta Barriguitas Oficial
+2. Pintura Segura Embarazadas
+3. Hipoalergénica y Dermatológica
+4. +500 Familias Felices ⭐4.8
+5. Envío Gratis a Toda Colombia
+6. Ideal para Baby Shower
+7. 15 Colores + 4 Pinceles
+8. 3 Plantillas Fáciles de Usar
+9. Regalo que Ella Recordará
+10. Videotutoriales Incluidos
+11. Kit Completo $190.000
+12. Momento Único en Familia
+13. Pancita de Arte en Minutos
+14. Sin Experiencia Artística
+15. Listo para Enviar Hoy
+
+**Pinned position 1 (rotación de 4):**
+
+- Kit Pinta Barriguitas Oficial
+- Pintura Segura Embarazadas
+- Envío Gratis a Colombia
+- Regalo Baby Shower Único
+
+**Headlines estacionales Día de la Madre (cargar Abr 20 – May 10):**
+
+- Regalo Único Día de la Madre
+- Para la Mamá que Espera
+- Experiencia que Recordará
+- Envío Antes del 10 de Mayo
+- El Regalo Más Tierno
+
+### Descriptions (máx 90 chars)
+
+**Evergreen (4):**
+
+1. Kit completo con 15 pinturas hipoalergénicas, plantillas y pinceles. Envío gratis.
+2. Crea un recuerdo inolvidable de tu embarazo. Dermatológicamente probado. 4.8★.
+3. El regalo de baby shower que realmente recordará. +500 familias felices en Colombia.
+4. Todo incluido: pinturas seguras, plantillas, pinceles y video tutorial paso a paso.
+
+**Estacional Día de la Madre:**
+
+- "Este Día de la Madre regálale un recuerdo inolvidable: Kit Pinta Barriguitas, envío gratis."
+- "Una experiencia en familia para la mamá embarazada. Entrega garantizada antes del 10 de mayo."
+
+### URLs
+
+- **Final URL:** `https://www.croko.co/kit-pinta-barriguitas`
+- **Display path:** `/kit/pinta-barriguitas`
+
+---
+
+## 6. Assets / Extensions
+
+- **Sitelinks (4):** `Qué incluye el kit` · `Opiniones reales` · `Video tutoriales` · `Preguntas frecuentes` (apuntar a anchors)
+- **Callouts:** `Envío gratis` · `Hipoalergénico` · `4.8★ (200 reseñas)` · `30 días garantía` · `Pago seguro Wompi` · `+500 familias`
+- **Structured snippets** (Tipo: "Featured"): `15 colores`, `4 pinceles`, `3 plantillas`, `Videotutorial`, `Plantilla con nombre`
+- **Price extension:** Kit Pinta Barriguitas — $190.000 COP — "Kit completo con envío gratis"
+- **Promotion extension** (estacional): Día de la Madre / Amor y Amistad / Black Friday / Navidad
+- **Call extension:** WhatsApp del negocio
+- **Image assets:** 5+ fotos reales del kit y de barrigas pintadas
+- **Logo + business name** (obligatorio desde 2023)
+
+---
+
+## 7. Estacionalidad Colombia (research DANE + calendario e-commerce)
+
+### Datos clave
+
+- **Pico nacimientos:** Marzo (#1) y Septiembre (#2) — DANE 2023-2024
+- **Valle nacimientos:** Junio (mes más bajo serie 2019-2024)
+- **Baby showers ocurren ~4-6 semanas antes del parto**
+- **Día de la Madre Colombia 2026:** Domingo 10 de mayo (31 de mayo en Cúcuta)
+- **Amor y Amistad Colombia 2026:** Sábado 19 de septiembre (3er sábado) — pico e-commerce #1 en Colombia (32.9% de activación)
+- **Black Friday 2026:** Nov 27
+- **Navidad:** Dec
+
+### Matriz de estacionalidad
+
+| Mes | Demanda | Driver | Acción presupuesto |
+|---|---|---|---|
+| **Ene** | Media | Embarazos enero → shower marzo | Baseline |
+| **Feb** | **ALTA** | Baby showers pre-marzo | **+30%** |
+| **Mar** | Media | Post-parto mayoría | Baseline |
+| **Abr 20 – May 10** | **ALTA** | **Día de la Madre** (ángulo regalo) | **+80%** |
+| **May 11-31** | Baja | Post-Mother's Day | **-30%** |
+| **Jun** | **MUY BAJA** | Valle de nacimientos | **-50%** |
+| **Jul** | Media | Preparación agosto | Baseline |
+| **Ago** | **ALTA** | Baby showers pre-septiembre | **+30%** |
+| **Sep 1-19** | **MÁXIMA** | **Amor y Amistad** + showers septiembre | **+80%** |
+| **Sep 20-30** | Media | Post evento | Baseline |
+| **Oct** | Media | — | Baseline |
+| **Nov** | **ALTA** | **Black Friday** + anticipación Navidad | **+60%** |
+| **Dic** | **ALTA** | **Navidad** (ángulo regalo diferente) | **+50%** |
+
+### Cómo aplicar con budget fijo de $300k/mes
+
+No puedes "subir" — tienes que **reasignar**:
+
+- **Ahorrar** en Mayo (2da mitad) y Junio → 150k esos meses
+- **Gastar** en Ago-Sep y Nov-Dic → 450k esos meses
+- **Promedio anual** sigue siendo ~300k/mes
+
+**Acción inmediata (Abril 2026):** lanzar antes del 20 de abril con foco Día de la Madre. Es tu mejor ventana de validación a corto plazo.
+
+---
+
+## 8. Impacto de la indexación (GSC) en Google Ads
+
+**Contexto:** croko.co tiene 1 de 12 páginas indexadas post-migración. Ver `INDEXATION-STATUS.md`.
+
+### Buenas noticias
+
+- **Google Ads NO requiere que las páginas estén indexadas.** Los anuncios corren igual.
+- Quality Score evalúa: relevancia keyword, CTR esperado, experiencia de landing page (velocidad, mobile, content match). **No evalúa index status.**
+- Ads traffic puede ayudar **indirectamente** a la indexación (brand searches, dwell time, engagement).
+
+### Lo que SÍ se afecta
+
+1. **PMax y Demand Gen** cruzan señales con organic signals → funcionan peor en dominios de baja autoridad. **Por eso no los incluimos.**
+2. **Dynamic Search Ads** requieren páginas indexadas → no usar.
+3. **Brand recognition:** Google puede no reconocer "Croko" como marca aún → sin protección de trademark.
+
+### Acciones complementarias (fuera de scope Ads)
+
+Desde `INDEXATION-STATUS.md` → lista de backlinks pendientes:
+
+1. Actualizar URL en Google Business Profile a `www.croko.co`
+2. Bios Instagram/TikTok → `croko.co`
+3. **Wompi checkout return_url** → confirmar que apunta a `croko.co`
+4. Directorios colombianos: Páginas Amarillas, Civico, Cylex
+5. Re-indexing de páginas stale (`/blog` y `/blog/salud-mental-embarazo-croko-tranquilamente`)
+
+> **TL;DR:** El problema de indexación no bloquea Google Ads, pero sí refuerza usar **solo Search** (no PMax) hasta recuperar autoridad.
+
+---
+
+## 9. Landing page blockers (arreglar ANTES de lanzar)
+
+Del audit SEO (`docs/seo/audit-kit-pinta-barriguitas-2026-03-31.md`) y `kit-pinta-barriguitas-header-improvements.md`:
+
+1. 🔴 **CRITICAL: Fix CTA desktop roto** (`headerDesktop.js:78`) — hoy linkea a sí misma en desktop. Sin arreglar, quemas 50% del budget de desktop en clics sin salida.
+2. 🔴 **CRITICAL: Alt text de imágenes** — todas usan `alt="Producto"` o `alt="Thumbnail N"`. Rompe image asset quality en Google Ads.
+3. 🟡 **H1 sin keyword** — cambiar a "Kit Pinta Barriguitas para Embarazadas"
+4. 🟡 **Sticky CTA** — validar que trackee `begin_checkout`
+5. 🟡 **4.8★ 200 reseñas** above-the-fold — boost CTR + trust
+
+**Quality Score estimate sin fixes: 4-5/10. Con fixes: 7-8/10 → −25% CPC.**
+
+---
+
+## 10. Budget tiers (referencia)
+
+| Nivel | COP/mes | COP/día | USD | Qué logras |
+|---|---|---|---|---|
+| 🟥 **Actual** | $300.000 | $10k | ~$75 | Funciona, pero learning lento (30-45 días), Manual CPC forzado, 1 ad group, difícil probar unit economics |
+| 🟧 **Mínimo viable** | $450.000 | $15k | ~$112 | Floor técnico: ~10 clics/día, 10-15 compras duras/mes con micro-conv, validar CPA en 21 días |
+| 🟨 **Sweet spot** | $750.000 – $900.000 | $25-30k | ~$190-225 | Alcanza 15 conv/mes → Smart Bidding viable. 2 ad groups activos. |
+| 🟩 **Cómodo** | $1.200.000 – $1.500.000 | $40-50k | ~$300-375 | Real optimization, A/B testing, múltiples ángulos, seasonal spikes |
+
+### Math del piso ($450k)
+
+- CPC promedio estimado Colombia (pregnancy/baby shower): $1.200-1.800 COP
+- Mínimo 10 clics/día para señal estadística
+- 10 × $1.500 = $15.000/día = **$450.000/mes**
+
+### Math del sweet spot ($800k)
+
+- Smart Bidding necesita 15 conv/mes (tCPA) o 30 (tROAS)
+- Con tracking multi-capa: hard purchase ~5-8 + begin_checkout ~15-25 + WA lead ~10-20 = **30-50 señales/mes**
+- Solo alcanzable con ~$800k/mes
+
+### Roadmap de escalamiento realista
+
+1. **Abril (resto):** $300k como piloto de 3 semanas → ángulo Día de la Madre
+2. **Mayo-Junio:** decidir con [scorecard día 21](./google-ads-day21-scorecard.md):
+   - Si CPA < $60k → subir a $750k/mes
+   - Si CPA $60-100k → mantener $450k mientras optimizas
+   - Si CPA > $100k → mantener $300k y atacar landing/creative antes que budget
+3. **Agosto:** independiente del CPA, topear $900k ese mes y el siguiente para el pico Amor y Amistad
+
+---
+
+## 11. Launch checklist
+
+### Bloque A — Tracking (día 1-3, NO lanzar sin esto)
+
+- [ ] Crear página `www.croko.co/gracias` con scripts de `wompi-tracking-technical-guide.md` (cambiar dominio)
+- [ ] Actualizar Wompi `return_url` → `croko.co/gracias?id={reference}&amount={amount_in_cents}`
+- [ ] Agregar `gtag('event','begin_checkout')` a TODOS los botones "Comprar" (desktop, mobile, sticky)
+- [ ] Agregar `gtag('event','generate_lead')` a clics WhatsApp
+- [ ] Capturar GCLID en localStorage en landing
+- [ ] n8n workflow: offline conversion import desde Frappe CRM → Google Ads API
+- [ ] Configurar 4 conversiones en Google Ads con primary/secondary correcto
+- [ ] Activar Enhanced Conversions for Leads
+
+### Bloque B — Landing page blockers (día 1-3)
+
+- [ ] Fix CTA desktop roto (`headerDesktop.js:78`)
+- [ ] Corregir alt text de imágenes (todas)
+- [ ] Cambiar H1 a keyword-rich
+
+### Bloque C — Google Ads (día 3-4)
+
+- [ ] Crear campaña Search "Kit Pinta Barriguitas - CO - Search"
+- [ ] Geo: Medellín, Cali, Bogotá radio 25 km, "People in"
+- [ ] Idioma: Español
+- [ ] Schedule: Lun-Dom 06:00-23:00
+- [ ] Ad Group 1A con keywords de Product Direct
+- [ ] 1 RSA con 15 headlines + 4 descriptions + versión Día de la Madre
+- [ ] Todos los extensions: sitelinks, callouts, structured snippets, call, image, logo
+- [ ] Negative keyword shared list
+- [ ] Manual CPC max bid: $2.000 COP
+- [ ] Daily budget: $10.000 COP
+- [ ] Attribution: Data-driven, 30-day click / 1-day view
+
+### Bloque D — Monitoreo (semanas 1-3)
+
+- [ ] Día 1-3: Search Terms Report cada 24h, negatives agresivo
+- [ ] Día 7: si <5 clics/día → subir CPC max a $2.500. Si >30 clics sin conv → pausar keywords peores
+- [ ] Día 14: primera revisión CPA, ajustar bids por ad group
+- [ ] **Día 21: ejecutar [scorecard](./google-ads-day21-scorecard.md) y decidir subir/mantener/pausar**
+
+---
+
+## 12. Qué NO hacer (con este budget)
+
+- ❌ **No** usar Smart Bidding mes 1 (sin volumen)
+- ❌ **No** activar Performance Max (indexación débil + budget insuficiente)
+- ❌ **No** hacer Broad Match en nada
+- ❌ **No** usar Dynamic Search Ads (requiere páginas indexadas)
+- ❌ **No** pagar por "regalo baby shower" en mes 1 (CPC alto)
+- ❌ **No** activar desktop con mismo bid que mobile hasta arreglar el CTA desktop roto
+- ❌ **No** subir budget antes del día 21 sin datos del scorecard
+
+---
+
+## 13. Referencias cruzadas
+
+- **Scorecard de decisión día 21:** [google-ads-day21-scorecard.md](./google-ads-day21-scorecard.md)
+- **Audit SEO del kit:** `docs/seo/audit-kit-pinta-barriguitas-2026-03-31.md`
+- **Estado de indexación:** `INDEXATION-STATUS.md`
+- **Plan de monitoreo migración:** `URL_MIGRATION_MONITORING_PLAN.md`
+- **Wompi tracking technical guide:** `wompi-tracking-technical-guide.md`
+- **Header improvements (CTA fix):** `kit-pinta-barriguitas-header-improvements.md`
+- **Wompi configuration:** `WOMPI_CONFIGURATION.md`
+- **User purchase journey:** `docs/USER_PURCHASE_JOURNEY.md`
+
+### Fuentes externas
+
+- [DANE - Nacimientos 2023 Colombia](https://www.dane.gov.co/index.php/estadisticas-por-tema/salud/nacimientos-y-defunciones/nacimientos/nacimientos-2023)
+- [Día de la Madre 2026 Colombia](https://www.calendariodecolombia.com/fechas/dia-de-la-madre-2026-en-colombia)
+- [Calendario campañas comerciales Colombia 2026](https://marketing4ecommerce.co/calendario-de-campanas-comerciales-en-colombia/)
+- [Calendario e-commerce 2026 fechas clave - Nubimetrics](https://academia.nubimetrics.com/fechas-importantes-ecommerce)
+- [Google Ads Offline Conversions API](https://developers.google.com/google-ads/api/docs/conversions/upload-clicks)
+
+---
+
+**Documento versión:** 2.0
+**Creado:** 2026-04-10
+**Próxima revisión:** después del día 21 post-launch (ajustar con data real)

--- a/docs/ads/google-ads-day21-scorecard.md
+++ b/docs/ads/google-ads-day21-scorecard.md
@@ -1,0 +1,231 @@
+# Google Ads Day-21 Scorecard — Kit Pinta Barriguitas
+
+**Propósito:** Decidir en el día 21 después del launch si **subir, mantener, optimizar o pausar** el presupuesto de Google Ads basado en datos reales, no en intuición.
+
+**Contexto de referencia:** Plan v2 — Single Search campaign, $300.000 COP/mes inicial, geo Medellín/Cali/Bogotá, producto Kit Pinta Barriguitas ($190.000 COP AOV).
+
+**Cuándo ejecutar:** Día 21 exacto después de lanzar la campaña
+**Cuánto tarda:** 30–40 minutos
+**Inputs requeridos:** Google Ads + GA4 + Frappe CRM (ventas WhatsApp con GCLID)
+
+---
+
+## Parte 1 — Recolectar métricas (10 min)
+
+Abre Google Ads → Campaigns → selecciona rango **"Últimos 21 días"** y anota:
+
+| Métrica | Dónde encontrarla | Tu valor |
+|---|---|---|
+| **Gasto total** | Cost column | $______ COP |
+| **Clics totales** | Clicks column | ______ |
+| **Impresiones** | Impressions column | ______ |
+| **CPC promedio** | Avg. CPC | $______ COP |
+| **CTR** | CTR column | ______% |
+| **Impression Share** | Search impr. share | ______% |
+| **Hard Purchases** | Conversions filtradas por `purchase` | ______ |
+| **Begin Checkouts** | Conversions filtradas por `begin_checkout` | ______ |
+| **WhatsApp Clicks** | Conversions filtradas por `generate_lead` | ______ |
+| **Ventas WhatsApp reales** | Frappe CRM → Orders con source=ads + GCLID | ______ |
+
+**Calcular manualmente:**
+
+- **Total compras atribuidas** = Hard Purchases + Ventas WhatsApp con GCLID = ______
+- **CPA real** = Gasto / Total compras = $______ COP
+- **CVR real** = Total compras / Clics = ______%
+- **ROAS** = (Total compras × $190.000) / Gasto = ______x
+
+---
+
+## Parte 2 — Scorecard (15 min)
+
+Marca cada fila con ✅ (pasa), ⚠️ (warning) o ❌ (falla):
+
+### A. Salud del tráfico (cantidad y calidad)
+
+| # | Criterio | ✅ Verde | ⚠️ Amarillo | ❌ Rojo | Tu resultado |
+|---|---|---|---|---|---|
+| A1 | **Clics/día promedio** | ≥7 | 4-6 | <4 | |
+| A2 | **CPC promedio** | <$1.500 | $1.500-2.500 | >$2.500 | |
+| A3 | **CTR** | >4% | 2-4% | <2% | |
+| A4 | **Impression Share** | >40% | 20-40% | <20% | |
+| A5 | **% clics mobile** | >60% | 40-60% | <40% | |
+
+> **Cómo leer:** A1-A2 te dicen si el budget compra suficiente tráfico. A3-A4 miden calidad de ads/keywords. A5 confirma que el audience real es mobile (si no, revisar CTA desktop).
+
+### B. Conversión (qué pasa después del clic)
+
+| # | Criterio | ✅ Verde | ⚠️ Amarillo | ❌ Rojo | Tu resultado |
+|---|---|---|---|---|---|
+| B1 | **CVR total** (compras/clics) | ≥2.5% | 1-2.5% | <1% | |
+| B2 | **Begin checkout rate** (begin_checkout/clics) | ≥8% | 4-8% | <4% | |
+| B3 | **Checkout → Purchase rate** (purchase/begin_checkout) | ≥20% | 10-20% | <10% | |
+| B4 | **WhatsApp close rate** (ventas WA/WA clicks) | ≥25% | 10-25% | <10% | |
+| B5 | **Tracking coverage** (¿GCLID llegó en el 80%+ de ventas?) | ≥80% | 50-80% | <50% | |
+
+> **Cómo leer:** Si B1 es verde pero B3 rojo → el problema es Wompi checkout (abandono). Si B2 verde + B3 rojo → gente hace clic pero no paga. Si B5 rojo → tu tracking está roto y todo lo demás es ruido.
+
+### C. Unit economics (lo que importa para decidir)
+
+| # | Criterio | ✅ Verde | ⚠️ Amarillo | ❌ Rojo | Tu resultado |
+|---|---|---|---|---|---|
+| C1 | **CPA real** vs target $57.000 | ≤$57k | $57k-$100k | >$100k | |
+| C2 | **ROAS** | ≥3.3x | 2-3.3x | <2x | |
+| C3 | **# hard purchases en 21 días** | ≥6 | 3-5 | <3 | |
+| C4 | **# total señales (hard + begin_checkout + WA)** | ≥20 | 10-20 | <10 | |
+| C5 | **Ingreso neto** (ventas × 190k − gasto Ads − costo producto) | positivo | breakeven | negativo | |
+
+> **Cómo leer:** C1+C2 son las métricas críticas de decisión. C3 te dice si Google Ads tiene suficiente señal para optimizar. C4 te dice si puedes pasar a Smart Bidding. C5 es el sanity check final.
+
+---
+
+## Parte 3 — Árbol de decisión (5 min)
+
+**Cuenta tus resultados en la sección C (Unit economics):**
+
+### 🟢 Escenario A — "Subir budget"
+
+**Condición:** C1 y C2 en verde, C3 ≥ 5
+
+**Decisión:** **Subir a $750.000 COP/mes inmediato**
+
+**Por qué:** estás por debajo de CPA target y hay volumen suficiente — cada peso adicional trae una venta rentable. Oportunidad real.
+
+**Acciones:**
+- Subir daily budget de $10k → $25k COP
+- Mantener Manual CPC **2 semanas más** mientras estabiliza
+- Al llegar a 15 hard purchases acumuladas → cambiar a Max Conversions
+- Activar ad group B (Baby Shower Activity)
+- Revisar search terms report 2x/semana
+
+### 🟡 Escenario B — "Mantener y optimizar"
+
+**Condición:** C1 o C2 en amarillo, C3 ≥ 3
+
+**Decisión:** **Mantener $300.000/mes 3 semanas más, optimizar sin subir**
+
+**Por qué:** las unit economics están tibias — subir budget sin arreglar el problema solo escala pérdidas.
+
+**Acciones:**
+- Pausar keywords con >30 clics y 0 conversiones
+- Revisar los 3 ads con peor CTR y reescribirlos
+- Si B3 es amarillo/rojo → testear nueva landing variant con trust signals above-the-fold
+- Agregar negative keywords agresivamente (del search terms report)
+- Reevaluar al día 42
+
+### 🟠 Escenario C — "Diagnóstico profundo"
+
+**Condición:** C1 rojo pero B1 verde (CPA malo pero CVR bueno)
+
+**Decisión:** **Problema de CPC, no de conversión — optimizar bids**
+
+**Por qué:** estás pagando demasiado por cada clic, pero cuando llegan convierten bien.
+
+**Acciones:**
+- Bajar max CPC de $2.000 → $1.500 en todos los keywords
+- Revisar Quality Score por keyword (Columns → Quality Score)
+- Keywords con QS <5 → reescribir ads o pausar
+- Pausar match types phrase, dejar solo exact match
+- Reducir geo a solo **una** ciudad (la que tenga mejor CPA) por 2 semanas
+
+### 🔴 Escenario D — "Bajar/Pausar"
+
+**Condición:** C1 rojo, C2 rojo, C5 rojo, o C4 <10
+
+**Decisión:** **Pausar campaña, no bajar budget**
+
+**Por qué:** bajar budget no arregla economics rotas — solo las haces más lentas. Mejor parar y arreglar la causa raíz.
+
+**Causas posibles a investigar (en orden):**
+
+1. **Tracking roto** (B5 rojo) → el problema no es la campaña, es que no estás midiendo bien. Arreglar n8n + GCLID primero.
+2. **Landing page problem** (B1 rojo a pesar de buen CTR) → el CTA desktop roto sigue sin arreglarse, o la página no convence. Arreglar landing antes de gastar otro peso.
+3. **Keyword intent mismatch** → estás pagando por búsquedas informacionales. Revisar search terms report → agregar 20+ negatives.
+4. **CPC irreal** (C1 rojo por A2 rojo) → el mercado es más caro de lo esperado. Considerar cambiar a estrategia orgánica + solo remarketing.
+5. **Producto/precio** → si todo lo demás se ve bien pero no hay ventas, el problema está en la oferta, no en Ads. Pausar y reevaluar producto/precio/timing.
+
+---
+
+## Parte 4 — Plantilla de reporte (5 min)
+
+Al terminar, copiar esta plantilla a `docs/ads/google-ads-day21-review-YYYY-MM-DD.md`:
+
+```markdown
+# Google Ads Day-21 Review — Kit Pinta Barriguitas
+**Fecha:** YYYY-MM-DD
+**Período:** [launch date] - [21 días después]
+
+## Resumen ejecutivo
+- **Gasto:** $______ COP
+- **Ventas (hard + WA con GCLID):** ___
+- **CPA real:** $______ COP (target: $57.000)
+- **ROAS:** ___x (target: 3.3x)
+- **Decisión:** [Subir / Mantener / Diagnóstico / Pausar]
+
+## Sección A — Tráfico
+[tabla con valores]
+**Conclusión:** _______________
+
+## Sección B — Conversión
+[tabla con valores]
+**Conclusión:** _______________
+
+## Sección C — Unit Economics
+[tabla con valores]
+**Conclusión:** _______________
+
+## Escenario detectado
+[A / B / C / D + razón]
+
+## Acciones a tomar esta semana
+1. ___
+2. ___
+3. ___
+
+## Próximo checkpoint
+Día ___ (___/___/2026)
+```
+
+---
+
+## Quick reference — Semáforo de 30 segundos
+
+Si no tienes tiempo para el scorecard completo, con estos 3 números decides:
+
+| Número | Verde | Amarillo | Rojo |
+|---|---|---|---|
+| **CPA 21 días** | ≤$57k | $57-100k | >$100k |
+| **# ventas 21 días** | ≥6 | 3-5 | <3 |
+| **ROAS** | ≥3.3x | 2-3.3x | <2x |
+
+- **3 verdes** → Subir budget a $750k/mes
+- **2 verdes + 1 amarillo** → Mantener, ajustar bids
+- **Cualquier rojo** → Diagnóstico profundo antes de subir
+- **2+ rojos** → Pausar y arreglar causa raíz
+
+---
+
+## Unit economics de referencia
+
+| Concepto | Valor |
+|---|---|
+| AOV (precio Kit) | $190.000 COP |
+| Target CAC (30% AOV) | $57.000 COP |
+| Break-even ROAS | 3.3x |
+| Target ROAS | 4.0x |
+| Min conv/mes para Smart Bidding (tCPA) | 15 |
+| Min conv/mes para Smart Bidding (tROAS) | 30 |
+
+## Umbrales de presupuesto
+
+| Nivel | COP/mes | Uso |
+|---|---|---|
+| Piloto actual | $300.000 | Validación inicial, Manual CPC forzado |
+| Mínimo viable | $450.000 | Floor técnico, ~10 clics/día |
+| Sweet spot | $750.000–$900.000 | Permite Smart Bidding (15+ conv/mes) |
+| Escalable | $1.200.000–$1.500.000 | 2+ ad groups, A/B testing, seasonal spikes |
+
+---
+
+**Documento versión:** 1.0
+**Creado:** 2026-04-10
+**Próxima revisión:** después del primer uso (ajustar thresholds con data real)

--- a/src/app/ClientLayout.js
+++ b/src/app/ClientLayout.js
@@ -8,11 +8,14 @@ import CenterLogoHeader from '@/containers/common/center-logo-header';
 import FooterSection from '@/containers/wedding/footer';
 import WhatsappRibbon from '@/containers/elements/common/whatsapp';
 import { PurchaseModalProvider } from '@/components/PurchaseModal';
+import useGclidCapture from '@/hooks/useGclidCapture';
 
 export default function ClientLayout({ children }) {
   const [loader, setLoader] = useState(true);
   const [goingUp, setGoingUp] = useState(false);
   const pathname = usePathname();
+
+  useGclidCapture();
 
   useEffect(() => {
     // Page Loader - Reduced to 200ms for better performance

--- a/src/components/StickyCTA.js
+++ b/src/components/StickyCTA.js
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import '@/assets/scss/sticky-cta.scss';
 import { usePurchaseModalContext } from '@/components/PurchaseModal';
+import { appendAttributionToMessage } from '@/lib/adsTracking';
 
 const StickyCTA = ({
     whatsappNumber = "573168161717",
@@ -26,8 +27,8 @@ const StickyCTA = ({
     }, []);
 
     const handleWhatsAppClick = () => {
-        const encodedMessage = encodeURIComponent(whatsappMessage);
-        const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodedMessage}`;
+        const messageWithRef = appendAttributionToMessage(whatsappMessage);
+        const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(messageWithRef)}`;
         window.open(whatsappUrl, '_blank');
     };
 

--- a/src/containers/elements/common/whatsapp.js
+++ b/src/containers/elements/common/whatsapp.js
@@ -1,5 +1,7 @@
-import React, { Fragment } from 'react';
+'use client';
+import React, { Fragment, useState, useEffect } from 'react';
 import IKImage from '@/components/IKImage';
+import { appendAttributionToMessage } from '@/lib/adsTracking';
 
 var whatsappRibbonStyles = {
   a: {
@@ -14,12 +16,24 @@ var whatsappRibbonStyles = {
 }
 
 const WhatsappRibbon = (props) => {
-  let message = props.kit ? 'Hola! 👋 Estoy interesada en el Kit de Pintura de Barriguita. Me gustaría saber más sobre:' : 'Hola, estoy interesado en maquillaje prenatal en Medellín.'
+  const baseMessage = props.kit
+    ? 'Hola! 👋 Estoy interesada en el Kit de Pintura de Barriguita. Me gustaría saber más sobre:'
+    : 'Hola, estoy interesado en maquillaje prenatal en Medellín.';
+
+  const [href, setHref] = useState(
+    `https://wa.me/573168161717?text=${encodeURIComponent(baseMessage)}`
+  );
+
+  useEffect(() => {
+    const enriched = appendAttributionToMessage(baseMessage);
+    setHref(`https://wa.me/573168161717?text=${encodeURIComponent(enriched)}`);
+  }, [baseMessage]);
+
   return (
     <Fragment>
       <a
         style={whatsappRibbonStyles.a}
-        href={`https://wa.me/573168161717?text=${message}`}
+        href={href}
         target="_blank"
         className={props.kit ? 'whatsapp-kit' : 'whatsapp-local'}
         aria-label="Contáctanos por WhatsApp"

--- a/src/hooks/useGclidCapture.js
+++ b/src/hooks/useGclidCapture.js
@@ -1,0 +1,11 @@
+'use client';
+import { useEffect } from 'react';
+import { captureAttribution } from '@/lib/adsTracking';
+
+const useGclidCapture = () => {
+  useEffect(() => {
+    captureAttribution();
+  }, []);
+};
+
+export default useGclidCapture;

--- a/src/hooks/useOrderTracking.js
+++ b/src/hooks/useOrderTracking.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { getAttribution } from '@/lib/adsTracking';
 
 // Fixed product price
 const FIXED_PRICE = 190000; // $190,000 COP
@@ -19,7 +20,10 @@ const useOrderTracking = (searchParams) => {
     // Use timeout to ensure GTM is fully loaded before pushing event
     if (!alreadyTracked) {
       const firePurchaseEvent = () => {
+        const attribution = getAttribution();
+
         window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({ ecommerce: null });
         window.dataLayer.push({
           event: 'purchase',
           ecommerce: {
@@ -32,9 +36,10 @@ const useOrderTracking = (searchParams) => {
               price: FIXED_PRICE,
               quantity: 1
             }]
-          }
+          },
+          attribution: attribution || undefined
         });
-        console.log('✓ GA4 Purchase event fired via GTM');
+        console.log('✓ GA4 Purchase event fired via GTM', { attribution });
 
         // Google Ads Conversion Tag
         // TODO: Replace AW-CONVERSION_ID/CONVERSION_LABEL with actual values from Google Ads

--- a/src/hooks/usePurchaseModal.js
+++ b/src/hooks/usePurchaseModal.js
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useCallback, useEffect } from 'react';
 import { getImageNames } from '@/data/designImages';
+import { getAttribution } from '@/lib/adsTracking';
 
 const STORAGE_KEY = 'croko_purchase_selections';
 const WOMPI_CHECKOUT_URL = 'https://checkout.wompi.co/l/BER6fQ';
@@ -129,6 +130,7 @@ export const usePurchaseModal = () => {
     try {
       const imageNames = getImageNames(data.selectedImages);
       const timestamp = new Date().toLocaleString('es-CO', { timeZone: 'America/Bogota' });
+      const attribution = getAttribution();
 
       const payload = {
         email: data.email,
@@ -136,7 +138,17 @@ export const usePurchaseModal = () => {
         disenos: imageNames.join(', '),
         nombre_bebe: data.babyName,
         fecha: timestamp,
-        ids_disenos: data.selectedImages.join(', ')
+        ids_disenos: data.selectedImages.join(', '),
+        gclid: attribution?.gclid || null,
+        gbraid: attribution?.gbraid || null,
+        wbraid: attribution?.wbraid || null,
+        utm_source: attribution?.utm_source || null,
+        utm_medium: attribution?.utm_medium || null,
+        utm_campaign: attribution?.utm_campaign || null,
+        utm_content: attribution?.utm_content || null,
+        utm_term: attribution?.utm_term || null,
+        landing_page: attribution?.landing_page || null,
+        first_seen_at: attribution?.first_seen_at || null
       };
 
       await fetch(N8N_WEBHOOK_URL, {

--- a/src/lib/adsTracking.js
+++ b/src/lib/adsTracking.js
@@ -1,0 +1,89 @@
+'use client';
+
+// Attribution capture and enrichment for Google Ads.
+// Click-based analytics events (WhatsApp clicks, purchase, begin_checkout)
+// are handled entirely by GTM (GTM-5H5LM4D).
+//
+// This module exists for two things GTM cannot do on its own:
+//   1. Persist Google Ads click IDs (gclid/gbraid/wbraid) + UTMs to localStorage
+//      so the n8n webhook can include them in the order payload and later
+//      import offline conversions (e.g. WhatsApp-closed sales) via the
+//      Google Ads Offline Conversion Import API.
+//   2. Inject a compact attribution reference into pre-purchase WhatsApp
+//      messages so the sales team can manually attribute chat sales.
+
+const STORAGE_KEY = 'croko_attribution';
+const TTL_DAYS = 90;
+
+const isBrowser = () => typeof window !== 'undefined';
+
+export const captureAttribution = () => {
+  if (!isBrowser()) return null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const gclid = params.get('gclid');
+    const gbraid = params.get('gbraid');
+    const wbraid = params.get('wbraid');
+    const hasNewClickId = Boolean(gclid || gbraid || wbraid);
+
+    const existing = getAttribution();
+
+    if (!hasNewClickId && existing) {
+      const updated = { ...existing, last_seen_at: Date.now() };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      return updated;
+    }
+
+    const attribution = {
+      gclid: gclid || existing?.gclid || null,
+      gbraid: gbraid || existing?.gbraid || null,
+      wbraid: wbraid || existing?.wbraid || null,
+      utm_source: params.get('utm_source') || existing?.utm_source || null,
+      utm_medium: params.get('utm_medium') || existing?.utm_medium || null,
+      utm_campaign: params.get('utm_campaign') || existing?.utm_campaign || null,
+      utm_content: params.get('utm_content') || existing?.utm_content || null,
+      utm_term: params.get('utm_term') || existing?.utm_term || null,
+      landing_page: hasNewClickId
+        ? window.location.pathname
+        : existing?.landing_page || window.location.pathname,
+      first_seen_at: existing?.first_seen_at || Date.now(),
+      last_seen_at: Date.now(),
+    };
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(attribution));
+    return attribution;
+  } catch (e) {
+    console.warn('adsTracking: captureAttribution failed', e);
+    return null;
+  }
+};
+
+export const getAttribution = () => {
+  if (!isBrowser()) return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    const ttlMs = TTL_DAYS * 24 * 60 * 60 * 1000;
+    if (data.first_seen_at && Date.now() - data.first_seen_at > ttlMs) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
+};
+
+export const appendAttributionToMessage = (message) => {
+  const attribution = getAttribution();
+  if (!attribution) return message;
+  const parts = [];
+  if (attribution.gclid) parts.push(`ads:${attribution.gclid.slice(0, 20)}`);
+  else if (attribution.gbraid) parts.push(`gbraid:${attribution.gbraid.slice(0, 20)}`);
+  else if (attribution.wbraid) parts.push(`wbraid:${attribution.wbraid.slice(0, 20)}`);
+  if (attribution.utm_campaign) parts.push(`camp:${attribution.utm_campaign}`);
+  else if (attribution.utm_source) parts.push(`src:${attribution.utm_source}`);
+  if (parts.length === 0) return message;
+  return `${message}\n\n_Ref: ${parts.join(' | ')}_`;
+};


### PR DESCRIPTION
Captures gclid/gbraid/wbraid and UTMs on landing, persists to localStorage for 90 days, and enriches the n8n webhook payload plus pre-purchase WhatsApp messages so chat-closed and Wompi sales can be imported as offline conversions. Event tracking remains in GTM.