### PR TITLE
Replace Wompi payment link with embedded widget checkout

### DIFF
--- a/src/app/api/wompi-signature/route.js
+++ b/src/app/api/wompi-signature/route.js
@@ -1,0 +1,29 @@
+import { createHash } from 'crypto';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function POST(request) {
+  const secret = process.env.WOMPI_INTEGRITY_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'integrity_secret_missing' }, { status: 500 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const { reference, amountInCents, currency } = body || {};
+  if (!reference || !amountInCents || !currency) {
+    return NextResponse.json({ error: 'missing_fields' }, { status: 400 });
+  }
+
+  const signature = createHash('sha256')
+    .update(`${reference}${amountInCents}${currency}${secret}`)
+    .digest('hex');
+
+  return NextResponse.json({ signature });
+}

--- a/src/components/PurchaseModal/PurchaseModal.scss
+++ b/src/components/PurchaseModal/PurchaseModal.scss
@@ -348,7 +348,7 @@ $girl-pink: #E91E8C;
   }
 }
 
-// Baby Name Step
+// Baby Name Step (also hosts order summary + payment status/error before Wompi widget)
 .baby-name-step {
   max-width: 400px;
   margin: 0 auto;
@@ -442,5 +442,79 @@ $girl-pink: #E91E8C;
         white-space: normal;
       }
     }
+  }
+}
+
+// Summary table + payment status/error (rendered inside .baby-name-step)
+.baby-name-step {
+  .summary-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    color: #555;
+
+    th,
+    td {
+      padding: 0.35rem 0;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      font-weight: 500;
+      color: #555;
+      width: 40%;
+      white-space: nowrap;
+      padding-right: 1rem;
+    }
+
+    td {
+      color: $primary-gold;
+      font-weight: 600;
+      word-break: break-word;
+    }
+
+    .summary-total-row {
+      th,
+      td {
+        border-top: 1px dashed rgba(192, 136, 47, 0.3);
+        padding-top: 0.75rem;
+        padding-bottom: 0;
+      }
+
+      th {
+        font-weight: 600;
+        color: #333;
+        font-size: 1rem;
+      }
+
+      td.total-value {
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: $primary-gold;
+      }
+    }
+  }
+
+  .payment-status {
+    background: rgba(192, 136, 47, 0.08);
+    border: 1px solid rgba(192, 136, 47, 0.3);
+    color: $primary-gold;
+    padding: 0.6rem 0.9rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    text-align: center;
+    margin-bottom: 0.75rem;
+  }
+
+  .payment-error {
+    background: #fdecea;
+    border: 1px solid #f5c2c0;
+    color: #b3261e;
+    padding: 0.6rem 0.9rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    text-align: center;
+    margin-bottom: 0.75rem;
   }
 }

--- a/src/components/PurchaseModal/index.js
+++ b/src/components/PurchaseModal/index.js
@@ -34,7 +34,10 @@ const PurchaseModalInner = () => {
   const {
     isOpen,
     currentStep,
+    totalSteps,
     selections,
+    isPaying,
+    paymentError,
     closeModal,
     setGender,
     toggleImage,
@@ -60,7 +63,7 @@ const PurchaseModalInner = () => {
   };
 
   const handleNext = () => {
-    if (currentStep === 3) {
+    if (currentStep === totalSteps) {
       proceedToCheckout();
     } else {
       nextStep();
@@ -68,8 +71,8 @@ const PurchaseModalInner = () => {
   };
 
   const getNextButtonText = () => {
-    if (currentStep === 3) {
-      return 'Continuar al pago';
+    if (currentStep === totalSteps) {
+      return isPaying ? 'Abriendo pago...' : 'Pagar con Wompi';
     }
     return 'Siguiente';
   };
@@ -85,7 +88,7 @@ const PurchaseModalInner = () => {
     >
       <ModalHeader toggle={closeModal}>
         <div className="modal-header-content">
-          <StepIndicator currentStep={currentStep} totalSteps={3} />
+          <StepIndicator currentStep={currentStep} totalSteps={totalSteps} />
           <h5 className="step-title">{getStepTitle()}</h5>
         </div>
       </ModalHeader>
@@ -112,13 +115,15 @@ const PurchaseModalInner = () => {
             onEmailChange={setEmail}
             gender={selections.gender}
             selectedImages={selections.selectedImages}
+            isPaying={isPaying}
+            paymentError={paymentError}
           />
         )}
       </ModalBody>
 
       <ModalFooter>
         {currentStep > 1 && (
-          <Button color="secondary" outline onClick={prevStep}>
+          <Button color="secondary" outline onClick={prevStep} disabled={isPaying}>
             Atrás
           </Button>
         )}
@@ -126,7 +131,7 @@ const PurchaseModalInner = () => {
           color="primary"
           onClick={handleNext}
           disabled={!canProceed()}
-          className={`btn-next ${currentStep === 3 ? 'btn-checkout-kit' : ''}`}
+          className={`btn-next ${currentStep === totalSteps ? 'btn-checkout-kit' : ''}`}
         >
           {getNextButtonText()}
         </Button>

--- a/src/components/PurchaseModal/steps/BabyNameStep.js
+++ b/src/components/PurchaseModal/steps/BabyNameStep.js
@@ -1,6 +1,17 @@
 import { getImageNames } from '@/data/designImages';
 
-const BabyNameStep = ({ babyName, onNameChange, email, onEmailChange, gender, selectedImages }) => {
+const FIXED_PRICE_LABEL = '$190.000';
+
+const BabyNameStep = ({
+  babyName,
+  onNameChange,
+  email,
+  onEmailChange,
+  gender,
+  selectedImages,
+  isPaying,
+  paymentError,
+}) => {
   const imageNames = getImageNames(selectedImages);
 
   return (
@@ -18,6 +29,7 @@ const BabyNameStep = ({ babyName, onNameChange, email, onEmailChange, gender, se
           placeholder="Ej: Sofía"
           maxLength={30}
           autoComplete="off"
+          disabled={isPaying}
         />
         <div className="char-count">{babyName.length}/30</div>
         <small className="form-text">
@@ -37,24 +49,41 @@ const BabyNameStep = ({ babyName, onNameChange, email, onEmailChange, gender, se
           onChange={(e) => onEmailChange(e.target.value)}
           placeholder="tu@email.com"
           autoComplete="email"
+          disabled={isPaying}
         />
       </div>
 
       <div className="selections-summary">
         <h6>Resumen de tu selección</h6>
-        <div className="summary-item">
-          <span className="label">Género:</span>
-          <span className="value">{gender === 'boy' ? 'Niño' : 'Niña'}</span>
-        </div>
-        <div className="summary-item">
-          <span className="label">Diseños:</span>
-          <span className="value">{imageNames.join(', ')}</span>
-        </div>
-        <div className="summary-total">
-          <span className="label">Total a pagar:</span>
-          <span className="total-value">$190.000</span>
-        </div>
+        <table className="summary-table">
+          <tbody>
+            <tr>
+              <th scope="row">Género</th>
+              <td>{gender === 'boy' ? 'Niño' : 'Niña'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Diseños</th>
+              <td>{imageNames.join(', ')}</td>
+            </tr>
+            <tr className="summary-total-row">
+              <th scope="row">Total a pagar</th>
+              <td className="total-value">{FIXED_PRICE_LABEL}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
+
+      {isPaying && (
+        <div className="payment-status" role="status" aria-live="polite">
+          Abriendo pasarela de pago...
+        </div>
+      )}
+
+      {paymentError && (
+        <div className="payment-error" role="alert">
+          {paymentError}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/hooks/usePurchaseModal.js
+++ b/src/hooks/usePurchaseModal.js
@@ -2,11 +2,13 @@
 import { useState, useCallback, useEffect } from 'react';
 import { getImageNames } from '@/data/designImages';
 import { getAttribution } from '@/lib/adsTracking';
+import { openWompiCheckout } from '@/lib/wompiWidget';
 
 const STORAGE_KEY = 'croko_purchase_selections';
-const WOMPI_CHECKOUT_URL = 'https://checkout.wompi.co/l/BER6fQ';
 const N8N_WEBHOOK_URL = process.env.NEXT_PUBLIC_N8N_WEBHOOK_URL;
 const N8N_WEBHOOK_KEY = process.env.NEXT_PUBLIC_N8N_WEBHOOK_KEY;
+const WOMPI_AMOUNT_CENTS = Number(process.env.NEXT_PUBLIC_WOMPI_AMOUNT_CENTS || 19000000);
+const TOTAL_STEPS = 3;
 
 const initialSelections = {
   gender: null,
@@ -15,10 +17,19 @@ const initialSelections = {
   email: ''
 };
 
+const generateOrderId = () => {
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return `CROKO-${Date.now()}-${suffix}`;
+};
+
 export const usePurchaseModal = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
   const [selections, setSelections] = useState(initialSelections);
+  const [orderId, setOrderId] = useState(null);
+  const [isPaying, setIsPaying] = useState(false);
+  const [paymentError, setPaymentError] = useState(null);
+  const [webhookSent, setWebhookSent] = useState(false);
 
   // Load saved selections from localStorage on mount
   useEffect(() => {
@@ -57,11 +68,15 @@ export const usePurchaseModal = () => {
   const openModal = useCallback(() => {
     setIsOpen(true);
     setCurrentStep(1);
+    setOrderId(generateOrderId());
+    setPaymentError(null);
+    setWebhookSent(false);
   }, []);
 
   const closeModal = useCallback(() => {
     setIsOpen(false);
     setCurrentStep(1);
+    setPaymentError(null);
   }, []);
 
   const setGender = useCallback((gender) => {
@@ -108,14 +123,18 @@ export const usePurchaseModal = () => {
       case 2:
         return selections.selectedImages.length === 4;
       case 3:
-        return selections.babyName.trim().length > 0 && isValidEmail(selections.email);
+        return (
+          !isPaying &&
+          selections.babyName.trim().length > 0 &&
+          isValidEmail(selections.email)
+        );
       default:
         return false;
     }
-  }, [currentStep, selections]);
+  }, [currentStep, selections, isPaying]);
 
   const nextStep = useCallback(() => {
-    if (canProceed() && currentStep < 3) {
+    if (canProceed() && currentStep < TOTAL_STEPS) {
       setCurrentStep(currentStep + 1);
     }
   }, [canProceed, currentStep]);
@@ -126,7 +145,7 @@ export const usePurchaseModal = () => {
     }
   }, [currentStep]);
 
-  const submitToWebhook = useCallback(async (data) => {
+  const submitToWebhook = useCallback(async (data, orderIdToUse) => {
     try {
       const imageNames = getImageNames(data.selectedImages);
       const timestamp = new Date().toLocaleString('es-CO', { timeZone: 'America/Bogota' });
@@ -139,16 +158,13 @@ export const usePurchaseModal = () => {
         nombre_bebe: data.babyName,
         fecha: timestamp,
         ids_disenos: data.selectedImages.join(', '),
+        order_id: orderIdToUse,
         gclid: attribution?.gclid || null,
-        gbraid: attribution?.gbraid || null,
-        wbraid: attribution?.wbraid || null,
+        fbclid: attribution?.fbclid || null,
         utm_source: attribution?.utm_source || null,
-        utm_medium: attribution?.utm_medium || null,
         utm_campaign: attribution?.utm_campaign || null,
-        utm_content: attribution?.utm_content || null,
-        utm_term: attribution?.utm_term || null,
-        landing_page: attribution?.landing_page || null,
-        first_seen_at: attribution?.first_seen_at || null
+        fbp: attribution?.fbp || null,
+        fbc: attribution?.fbc || null
       };
 
       await fetch(N8N_WEBHOOK_URL, {
@@ -168,32 +184,72 @@ export const usePurchaseModal = () => {
   }, []);
 
   const proceedToCheckout = useCallback(async () => {
-    if (!canProceed()) return;
+    if (isPaying) return;
+
+    const currentOrderId = orderId || generateOrderId();
+    if (!orderId) setOrderId(currentOrderId);
+
+    setPaymentError(null);
+    setIsPaying(true);
 
     // Save final selections
     saveSelections(selections);
 
-    // Submit to n8n webhook (don't wait for response to avoid blocking)
-    submitToWebhook(selections);
+    // Fire begin_checkout webhook once per order
+    if (!webhookSent) {
+      submitToWebhook(selections, currentOrderId);
+      setWebhookSent(true);
+    }
 
-    // Redirect to Wompi checkout
-    window.open(WOMPI_CHECKOUT_URL, '_blank');
-
-    // Close modal
-    closeModal();
-  }, [canProceed, selections, saveSelections, submitToWebhook, closeModal]);
+    try {
+      await openWompiCheckout({
+        orderId: currentOrderId,
+        amountInCents: WOMPI_AMOUNT_CENTS,
+        currency: 'COP',
+        email: selections.email,
+        fullName: selections.babyName,
+        onResult: (result) => {
+          setIsPaying(false);
+          const tx = result?.transaction;
+          if (tx?.status === 'APPROVED') {
+            closeModal();
+            const params = new URLSearchParams({
+              id: tx.id || '',
+              reference: tx.reference || currentOrderId,
+              status: tx.status,
+            });
+            window.location.href = `/gracias?${params.toString()}`;
+          } else if (tx?.status) {
+            setPaymentError(`Pago ${tx.status.toLowerCase()}. Puedes intentarlo de nuevo.`);
+          }
+          // If user closed widget without a transaction, stay on step 4 silently.
+        },
+      });
+    } catch (err) {
+      console.error('wompi widget error:', err);
+      setIsPaying(false);
+      setPaymentError('No se pudo abrir el pago. Intenta nuevamente.');
+    }
+  }, [isPaying, orderId, selections, webhookSent, saveSelections, submitToWebhook, closeModal]);
 
   const resetSelections = useCallback(() => {
     setSelections(initialSelections);
     localStorage.removeItem(STORAGE_KEY);
     setCurrentStep(1);
+    setOrderId(null);
+    setWebhookSent(false);
+    setPaymentError(null);
   }, []);
 
   return {
     // State
     isOpen,
     currentStep,
+    totalSteps: TOTAL_STEPS,
     selections,
+    orderId,
+    isPaying,
+    paymentError,
 
     // Actions
     openModal,

--- a/src/lib/adsTracking.js
+++ b/src/lib/adsTracking.js
@@ -17,6 +17,12 @@ const TTL_DAYS = 90;
 
 const isBrowser = () => typeof window !== 'undefined';
 
+const getCookie = (name) => {
+  if (!isBrowser()) return null;
+  const m = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return m ? decodeURIComponent(m[2]) : null;
+};
+
 export const captureAttribution = () => {
   if (!isBrowser()) return null;
   try {
@@ -24,12 +30,20 @@ export const captureAttribution = () => {
     const gclid = params.get('gclid');
     const gbraid = params.get('gbraid');
     const wbraid = params.get('wbraid');
-    const hasNewClickId = Boolean(gclid || gbraid || wbraid);
+    const fbclid = params.get('fbclid');
+    const hasNewClickId = Boolean(gclid || gbraid || wbraid || fbclid);
 
     const existing = getAttribution();
+    const fbp = getCookie('_fbp');
+    const fbc = getCookie('_fbc');
 
     if (!hasNewClickId && existing) {
-      const updated = { ...existing, last_seen_at: Date.now() };
+      const updated = {
+        ...existing,
+        fbp: fbp || existing.fbp || null,
+        fbc: fbc || existing.fbc || null,
+        last_seen_at: Date.now(),
+      };
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     }
@@ -38,6 +52,7 @@ export const captureAttribution = () => {
       gclid: gclid || existing?.gclid || null,
       gbraid: gbraid || existing?.gbraid || null,
       wbraid: wbraid || existing?.wbraid || null,
+      fbclid: fbclid || existing?.fbclid || null,
       utm_source: params.get('utm_source') || existing?.utm_source || null,
       utm_medium: params.get('utm_medium') || existing?.utm_medium || null,
       utm_campaign: params.get('utm_campaign') || existing?.utm_campaign || null,
@@ -46,6 +61,8 @@ export const captureAttribution = () => {
       landing_page: hasNewClickId
         ? window.location.pathname
         : existing?.landing_page || window.location.pathname,
+      fbp: fbp || existing?.fbp || null,
+      fbc: fbc || existing?.fbc || null,
       first_seen_at: existing?.first_seen_at || Date.now(),
       last_seen_at: Date.now(),
     };

--- a/src/lib/wompiWidget.js
+++ b/src/lib/wompiWidget.js
@@ -1,0 +1,88 @@
+'use client';
+
+const WIDGET_SRC = 'https://checkout.wompi.co/widget.js';
+let loaderPromise = null;
+
+const loadWidgetScript = () => {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('wompi: window undefined'));
+  }
+  if (window.WidgetCheckout) return Promise.resolve(window.WidgetCheckout);
+  if (loaderPromise) return loaderPromise;
+
+  loaderPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[src="${WIDGET_SRC}"]`);
+    const onLoad = () => {
+      if (window.WidgetCheckout) resolve(window.WidgetCheckout);
+      else reject(new Error('wompi: WidgetCheckout not exposed after load'));
+    };
+    const onError = () => reject(new Error('wompi: failed to load widget.js'));
+
+    if (existing) {
+      existing.addEventListener('load', onLoad, { once: true });
+      existing.addEventListener('error', onError, { once: true });
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = WIDGET_SRC;
+    script.async = true;
+    script.addEventListener('load', onLoad, { once: true });
+    script.addEventListener('error', onError, { once: true });
+    document.head.appendChild(script);
+  });
+
+  return loaderPromise;
+};
+
+const fetchSignature = async ({ reference, amountInCents, currency }) => {
+  const res = await fetch('/api/wompi-signature', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reference, amountInCents, currency }),
+  });
+  if (!res.ok) throw new Error(`wompi: signature endpoint ${res.status}`);
+  const data = await res.json();
+  if (!data.signature) throw new Error('wompi: missing signature in response');
+  return data.signature;
+};
+
+export const openWompiCheckout = async ({
+  orderId,
+  amountInCents,
+  currency = 'COP',
+  email,
+  fullName,
+  onResult,
+}) => {
+  const publicKey = process.env.NEXT_PUBLIC_WOMPI_PUBLIC_KEY;
+  if (!publicKey) throw new Error('wompi: NEXT_PUBLIC_WOMPI_PUBLIC_KEY missing');
+
+  const [WidgetCheckout, signature] = await Promise.all([
+    loadWidgetScript(),
+    fetchSignature({ reference: orderId, amountInCents, currency }),
+  ]);
+
+  // Wompi's WAF rejects http://localhost redirect URLs. Skip redirectUrl in dev;
+  // the JS callback still fires with the transaction result.
+  const isLocalhost = /^(localhost|127\.0\.0\.1)$/i.test(window.location.hostname);
+  const config = {
+    currency,
+    amountInCents,
+    reference: orderId,
+    publicKey,
+    signature: { integrity: signature },
+    customerData: {
+      email,
+      fullName,
+    },
+  };
+  if (!isLocalhost) {
+    config.redirectUrl = `${window.location.origin}/gracias`;
+  }
+
+  const checkout = new WidgetCheckout(config);
+
+  checkout.open((result) => {
+    if (typeof onResult === 'function') onResult(result);
+  });
+};


### PR DESCRIPTION
- Generate stable order_id at modal open and persist as Wompi reference
- Add server-side integrity signature endpoint (/api/wompi-signature)
- Load WidgetCheckout via lazy script loader and open from step 3
- Skip redirectUrl on localhost to bypass Wompi WAF block
- Wire payment status and error states inline in BabyNameStep
- Render order summary as aligned table in step 3
- Capture fbclid, _fbp, _fbc for Meta CAPI matching
- Send order_id and minimal attribution payload to begin_checkout webhook