### PR TITLE
Enable Wompi widget shipping address and legal ID collection

### DIFF
--- a/src/lib/wompiWidget.js
+++ b/src/lib/wompiWidget.js
@@ -71,6 +71,8 @@ export const openWompiCheckout = async ({
     reference: orderId,
     publicKey,
     signature: { integrity: signature },
+    collectShipping: 'true',
+    collectCustomerLegalId: 'true',
     customerData: {
       email,
       fullName,


### PR DESCRIPTION
Pass collectShipping and collectCustomerLegalId flags as strings ('true') so the widget shows the shipping form and identity document field for the customer to fill in directly inside the overlay.