### PR TITLE
Fix Wompi checkout hang in in-app browsers; add timeouts + diagnostics

### DIFF
--- a/src/app/api/diag/route.js
+++ b/src/app/api/diag/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+// Receives checkout-funnel diagnostics from the client and logs them as a
+// single structured line to the server console (visible in the host/deploy
+// logs). Intentionally minimal: no storage, no auth, no PII beyond what the
+// client already controls. Always 204 so sendBeacon never retries.
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const safe = {
+      stage: String(body?.stage || 'unknown').slice(0, 64),
+      sid: String(body?.sid || '').slice(0, 64),
+      app: body?.app ? String(body.app).slice(0, 32) : undefined,
+      ms: typeof body?.ms === 'number' ? body.ms : undefined,
+      error: body?.error ? String(body.error).slice(0, 300) : undefined,
+      orderId: body?.orderId ? String(body.orderId).slice(0, 64) : undefined,
+      ua: String(body?.ua || '').slice(0, 400),
+      url: String(body?.url || '').slice(0, 300),
+      ts: body?.ts,
+    };
+    console.log('[checkout-diag]', JSON.stringify(safe));
+  } catch {
+    console.log('[checkout-diag] unparseable beacon');
+  }
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/lib/diag.js
+++ b/src/lib/diag.js
@@ -1,0 +1,53 @@
+'use client';
+
+// Lightweight client diagnostics for the checkout funnel. Sends a structured
+// beacon to /api/diag so we can see *where* the Wompi handoff fails on real
+// user devices (console.log is invisible on phones). Best-effort, never throws,
+// never blocks the checkout flow. Uses sendBeacon so events survive the
+// full-page redirect to Wompi Web Checkout.
+
+import { getUA } from './inAppBrowser';
+
+let sessionId = null;
+const getSessionId = () => {
+  if (sessionId) return sessionId;
+  try {
+    sessionId =
+      sessionStorage.getItem('croko_diag_sid') ||
+      `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    sessionStorage.setItem('croko_diag_sid', sessionId);
+  } catch {
+    sessionId = `${Date.now().toString(36)}-nostore`;
+  }
+  return sessionId;
+};
+
+export const logDiag = (stage, extra = {}) => {
+  if (typeof window === 'undefined') return;
+  try {
+    const payload = JSON.stringify({
+      stage,
+      sid: getSessionId(),
+      ts: new Date().toISOString(),
+      ua: getUA(),
+      url: window.location.href,
+      ...extra,
+    });
+
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(
+        '/api/diag',
+        new Blob([payload], { type: 'application/json' })
+      );
+      return;
+    }
+    fetch('/api/diag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    // diagnostics must never break checkout
+  }
+};

--- a/src/lib/inAppBrowser.js
+++ b/src/lib/inAppBrowser.js
@@ -1,0 +1,40 @@
+'use client';
+
+// Detect embedded webviews (Instagram/Facebook/TikTok/etc.) where the Wompi
+// JS widget (popup/iframe based) frequently fails to open. For these we fall
+// back to the full-page Wompi Web Checkout redirect, which is a top-level
+// navigation and works everywhere.
+
+export const getUA = () =>
+  (typeof navigator !== 'undefined' && navigator.userAgent) || '';
+
+export const detectInAppBrowser = (ua = getUA()) => {
+  if (!ua) return { isInApp: false, app: null };
+
+  const tests = [
+    ['facebook', /\bFBAN\/|\bFBAV\/|\bFB_IAB\b|FBIOS|FB4A/i],
+    ['instagram', /\bInstagram\b/i],
+    ['tiktok', /\bBytedanceWebview\b|musical_ly|\bTikTok\b|trill/i],
+    ['messenger', /\bMessenger\b/i],
+    ['line', /\bLine\//i],
+    ['snapchat', /\bSnapchat\b/i],
+    ['twitter', /\bTwitter\b/i],
+    ['pinterest', /\bPinterest\b/i],
+    ['linkedin', /\bLinkedInApp\b/i],
+  ];
+
+  for (const [app, re] of tests) {
+    if (re.test(ua)) return { isInApp: true, app };
+  }
+
+  // Generic Android WebView heuristic: "wv" token, or Version/x.x + Chrome
+  // without a real browser brand. Conservative to avoid false positives.
+  const isAndroid = /Android/i.test(ua);
+  if (isAndroid && /; wv\)/i.test(ua)) {
+    return { isInApp: true, app: 'android-webview' };
+  }
+
+  return { isInApp: false, app: null };
+};
+
+export const isInAppBrowser = (ua) => detectInAppBrowser(ua).isInApp;

--- a/src/lib/wompiWidget.js
+++ b/src/lib/wompiWidget.js
@@ -1,7 +1,21 @@
 'use client';
 
+import { detectInAppBrowser } from './inAppBrowser';
+import { logDiag } from './diag';
+
 const WIDGET_SRC = 'https://checkout.wompi.co/widget.js';
+const WEB_CHECKOUT_URL = 'https://checkout.wompi.co/p/';
+const SCRIPT_TIMEOUT_MS = 12000;
+const SIGNATURE_TIMEOUT_MS = 10000;
 let loaderPromise = null;
+
+const withTimeout = (promise, ms, label) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`wompi: ${label} timed out (${ms}ms)`)), ms)
+    ),
+  ]);
 
 const loadWidgetScript = () => {
   if (typeof window === 'undefined') {
@@ -29,21 +43,71 @@ const loadWidgetScript = () => {
     script.addEventListener('load', onLoad, { once: true });
     script.addEventListener('error', onError, { once: true });
     document.head.appendChild(script);
+  }).catch((err) => {
+    // Reset so a retry can re-attempt the load instead of reusing a
+    // permanently-rejected promise.
+    loaderPromise = null;
+    throw err;
   });
 
   return loaderPromise;
 };
 
 const fetchSignature = async ({ reference, amountInCents, currency }) => {
-  const res = await fetch('/api/wompi-signature', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ reference, amountInCents, currency }),
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SIGNATURE_TIMEOUT_MS);
+  try {
+    const res = await fetch('/api/wompi-signature', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reference, amountInCents, currency }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`wompi: signature endpoint ${res.status}`);
+    const data = await res.json();
+    if (!data.signature) throw new Error('wompi: missing signature in response');
+    return data.signature;
+  } catch (err) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`wompi: signature fetch timed out (${SIGNATURE_TIMEOUT_MS}ms)`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// Full-page redirect to Wompi's hosted Web Checkout. This is a top-level
+// navigation (no popup, no cross-origin iframe), so it works inside Instagram /
+// Facebook / TikTok in-app webviews where the JS widget silently fails.
+const redirectToWebCheckout = ({
+  orderId,
+  amountInCents,
+  currency,
+  email,
+  fullName,
+  signature,
+  publicKey,
+}) => {
+  const params = new URLSearchParams({
+    'public-key': publicKey,
+    currency,
+    'amount-in-cents': String(amountInCents),
+    reference: orderId,
+    'signature:integrity': signature,
+    'collect-shipping': 'true',
+    'collect-customer-legal-id': 'true',
   });
-  if (!res.ok) throw new Error(`wompi: signature endpoint ${res.status}`);
-  const data = await res.json();
-  if (!data.signature) throw new Error('wompi: missing signature in response');
-  return data.signature;
+  if (email) params.set('customer-data:email', email);
+  if (fullName) params.set('customer-data:full-name', fullName);
+
+  const isLocalhost = /^(localhost|127\.0\.0\.1)$/i.test(window.location.hostname);
+  if (!isLocalhost) {
+    params.set('redirect-url', `${window.location.origin}/gracias`);
+  }
+
+  logDiag('wompi_redirect_navigate', { orderId });
+  window.location.href = `${WEB_CHECKOUT_URL}?${params.toString()}`;
 };
 
 export const openWompiCheckout = async ({
@@ -57,10 +121,63 @@ export const openWompiCheckout = async ({
   const publicKey = process.env.NEXT_PUBLIC_WOMPI_PUBLIC_KEY;
   if (!publicKey) throw new Error('wompi: NEXT_PUBLIC_WOMPI_PUBLIC_KEY missing');
 
-  const [WidgetCheckout, signature] = await Promise.all([
-    loadWidgetScript(),
-    fetchSignature({ reference: orderId, amountInCents, currency }),
-  ]);
+  const { isInApp, app } = detectInAppBrowser();
+  logDiag('wompi_checkout_start', { orderId, isInApp, app });
+
+  const t0 = Date.now();
+  let signature;
+  try {
+    signature = await withTimeout(
+      fetchSignature({ reference: orderId, amountInCents, currency }),
+      SIGNATURE_TIMEOUT_MS,
+      'signature'
+    );
+    logDiag('wompi_signature_ok', { orderId, ms: Date.now() - t0 });
+  } catch (err) {
+    logDiag('wompi_signature_fail', { orderId, error: err?.message });
+    throw err;
+  }
+
+  // In-app webviews: skip the popup/iframe widget entirely and hand off via
+  // a full-page redirect. The page navigates away, so onResult never fires
+  // here — the return trip lands on /gracias and useOrderTracking takes over.
+  if (isInApp) {
+    redirectToWebCheckout({
+      orderId,
+      amountInCents,
+      currency,
+      email,
+      fullName,
+      signature,
+      publicKey,
+    });
+    return;
+  }
+
+  let WidgetCheckout;
+  const tScript = Date.now();
+  try {
+    WidgetCheckout = await withTimeout(
+      loadWidgetScript(),
+      SCRIPT_TIMEOUT_MS,
+      'widget.js load'
+    );
+    logDiag('wompi_script_ok', { orderId, ms: Date.now() - tScript });
+  } catch (err) {
+    logDiag('wompi_script_fail', { orderId, error: err?.message });
+    // Script blocked but signature is valid → degrade gracefully to the
+    // hosted redirect instead of dead-ending the user.
+    redirectToWebCheckout({
+      orderId,
+      amountInCents,
+      currency,
+      email,
+      fullName,
+      signature,
+      publicKey,
+    });
+    return;
+  }
 
   // Wompi's WAF rejects http://localhost redirect URLs. Skip redirectUrl in dev;
   // the JS callback still fires with the transaction result.
@@ -82,9 +199,18 @@ export const openWompiCheckout = async ({
     config.redirectUrl = `${window.location.origin}/gracias`;
   }
 
-  const checkout = new WidgetCheckout(config);
-
-  checkout.open((result) => {
-    if (typeof onResult === 'function') onResult(result);
-  });
+  try {
+    const checkout = new WidgetCheckout(config);
+    logDiag('wompi_widget_open_called', { orderId });
+    checkout.open((result) => {
+      logDiag('wompi_widget_result', {
+        orderId,
+        status: result?.transaction?.status || 'none',
+      });
+      if (typeof onResult === 'function') onResult(result);
+    });
+  } catch (err) {
+    logDiag('wompi_widget_open_throw', { orderId, error: err?.message });
+    throw err;
+  }
 };


### PR DESCRIPTION
Users reaching the site via Instagram/Facebook/TikTok in-app webviews hit a frozen "Abriendo pasarela de pago..." button: the JS widget's popup/ iframe is blocked by the webview, so checkout.open() silently no-ops with no callback and no error.

- inAppBrowser.js: UA-based detection of in-app webviews
- wompiWidget.js: route in-app browsers to Wompi hosted Web Checkout (full-page redirect, immune to popup/iframe blocking); also degrade to redirect if widget.js fails to load in a normal browser
- Add 10s signature-fetch and 12s widget.js-load timeouts so the button errors loudly instead of hanging forever; reset loaderPromise on failure
- diag.js + /api/diag: sendBeacon instrumentation of every checkout stage to the server console for real-device debugging

Attribution unaffected: redirect returns to /gracias?id= (handled by useOrderTracking) and server-side conversion still flows via Wompi->n8n.