### PR TITLE
Route all Wompi checkouts through hosted redirect; gate /gracias on r…

### DIFF
--- a/src/app/gracias/page.js
+++ b/src/app/gracias/page.js
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import useOrderTracking from '@/hooks/useOrderTracking';
 import useWhatsAppRedirect from '@/hooks/useWhatsAppRedirect';
 import SuccessBanner from '@/components/gracias/SuccessBanner';
+import PaymentIssueBanner from '@/components/gracias/PaymentIssueBanner';
 import OrderDetailsSection from '@/components/gracias/OrderDetailsSection';
 import LoadingState from '@/components/gracias/LoadingState';
 import GoogleCustomerReviewsOptIn from '@/components/gracias/GoogleCustomerReviewsOptIn';
@@ -13,12 +14,24 @@ import '@/assets/scss/gracias.scss';
 // Content component that uses useSearchParams
 function GraciasContent() {
   const searchParams = useSearchParams();
-  const { orderData } = useOrderTracking(searchParams);
+  const { orderData, paymentStatus } = useOrderTracking(searchParams);
   const handleWhatsAppRedirect = useWhatsAppRedirect(orderData?.orderId);
 
-  // Show loading state while initializing
-  if (!orderData) {
-    return <LoadingState message="Cargando..." />;
+  // Show loading state while we resolve the transaction status with Wompi.
+  if (!orderData || paymentStatus === null) {
+    return <LoadingState message="Confirmando tu pago..." />;
+  }
+
+  // Only an approved payment gets the full confirmation experience. Any other
+  // outcome (declined, pending, unknown) shows the issue banner with a retry
+  // path instead of a false "thank you for your purchase".
+  if (paymentStatus !== 'APPROVED') {
+    return (
+      <PaymentIssueBanner
+        status={paymentStatus}
+        reference={orderData.orderId}
+      />
+    );
   }
 
   return (

--- a/src/components/gracias/PaymentIssueBanner.js
+++ b/src/components/gracias/PaymentIssueBanner.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Container } from 'reactstrap';
+import Title from '@/components/common/Title';
+
+// Shown on /gracias when the buyer returns from Wompi WITHOUT an approved
+// payment. PENDING (e.g. PSE awaiting bank confirmation) gets a reassuring
+// "we're confirming" message; everything else (DECLINED/VOIDED/ERROR/UNKNOWN)
+// gets a clear "it didn't go through, try again" with a path back to the cart.
+const PaymentIssueBanner = ({ status, reference }) => {
+  const isPending = status === 'PENDING';
+
+  // Re-open the purchase modal on the homepage pre-filled at the last step,
+  // reusing the same ?cart= recovery entry point the abandoned-cart emails use.
+  const retryHref = reference ? `/?cart=${encodeURIComponent(reference)}` : '/';
+
+  return (
+    <section className="gracias-hero py-5">
+      <Container>
+        <div className="text-center mb-4" style={{ maxWidth: 620, margin: '0 auto' }}>
+          <div className="mb-4">
+            <i
+              className={`fa ${isPending ? 'fa-clock-o' : 'fa-exclamation-circle'} fa-5x ${isPending ? 'text-gold' : 'text-muted'}`}
+            ></i>
+          </div>
+
+          {isPending ? (
+            <>
+              <Title heading="Estamos confirmando tu pago" />
+              <p className="lead text-muted mt-3">
+                Tu pago quedó en proceso (esto pasa con algunos pagos PSE).
+                Apenas tu banco lo confirme te llega el correo de tu pedido.
+                No necesitas hacer nada más.
+              </p>
+              <p className="text-muted mt-3">
+                ¿Dudas? Escríbele a Carolina por WhatsApp y te ayuda a
+                confirmarlo.
+              </p>
+            </>
+          ) : (
+            <>
+              <Title heading="Tu pago no se completó" />
+              <p className="lead text-muted mt-3">
+                No te preocupes — no se hizo ningún cobro. A veces el banco
+                pide aprobación en la app, o se cae el PSE un momento. Puedes
+                intentarlo de nuevo.
+              </p>
+              <div className="mt-4">
+                <a href={retryHref} className="btn btn-default btn-gradient">
+                  Intentar el pago de nuevo
+                </a>
+              </div>
+              <p className="text-muted mt-4">
+                Si prefieres, Carolina te ayuda a coordinar el pago por
+                WhatsApp (PSE, tarjeta, Nequi, Daviplata o contra entrega en
+                Medellín).
+              </p>
+            </>
+          )}
+        </div>
+      </Container>
+    </section>
+  );
+};
+
+export default PaymentIssueBanner;

--- a/src/hooks/useOrderTracking.js
+++ b/src/hooks/useOrderTracking.js
@@ -5,95 +5,147 @@ import { getFlatSelections, clearCartState } from '@/lib/cartState';
 // Fixed product price
 const FIXED_PRICE = 190000; // $190,000 COP
 
+// Resolve the real transaction outcome. The legacy widget path used to pass
+// `status` in the URL directly, but Wompi's hosted Web Checkout redirect only
+// returns `?id=<tx>&env=<env>` — no status — so we must query Wompi's public
+// transaction endpoint to learn whether the payment actually went through.
+// Without this gate a DECLINED card returning to /gracias would look like a
+// completed sale (false success page, inflated GA4 purchases, cart cleared).
+const fetchWompiStatus = async (transactionId, env) => {
+  const base =
+    env === 'test'
+      ? 'https://sandbox.wompi.co/v1'
+      : 'https://production.wompi.co/v1';
+  const res = await fetch(`${base}/transactions/${transactionId}`);
+  if (!res.ok) throw new Error(`wompi tx lookup ${res.status}`);
+  const json = await res.json();
+  return json?.data?.status || null;
+};
+
 const useOrderTracking = (searchParams) => {
   const [orderData, setOrderData] = useState(null);
+  // null = still resolving; otherwise APPROVED | PENDING | DECLINED | VOIDED |
+  // ERROR | UNKNOWN. The page branches its UI on this.
+  const [paymentStatus, setPaymentStatus] = useState(null);
   const [trackingFired, setTrackingFired] = useState(false);
 
   useEffect(() => {
-    // Extract transaction ID from URL (Wompi sends 'id' parameter)
+    let cancelled = false;
+
+    // Wompi sends 'id'; the legacy widget path sent 'reference' + 'status'.
     const transactionId = searchParams.get('id') || searchParams.get('reference');
+    const urlStatus = searchParams.get('status');
+    const env = searchParams.get('env');
 
-    // Check if we've already tracked this purchase
-    const purchaseKey = transactionId ? `purchase_tracked_${transactionId}` : null;
-    const alreadyTracked = purchaseKey ? sessionStorage.getItem(purchaseKey) : false;
-
-    // Fire GTM dataLayer event for purchase (only once per transaction)
-    // Use timeout to ensure GTM is fully loaded before pushing event
-    if (!alreadyTracked) {
-      const firePurchaseEvent = () => {
-        const attribution = getAttribution();
-
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({ ecommerce: null });
-        window.dataLayer.push({
-          event: 'purchase',
-          ecommerce: {
-            transaction_id: transactionId || 'direct_visit',
-            value: FIXED_PRICE,
-            currency: 'COP',
-            items: [{
-              item_id: 'kit_pinta_barriguita',
-              item_name: 'Kit Pinta Barriguita – Todo Incluido',
-              price: FIXED_PRICE,
-              quantity: 1
-            }]
-          },
-          attribution: attribution || undefined
-        });
-        console.log('✓ GA4 Purchase event fired via GTM', { attribution });
-
-        if (purchaseKey) {
-          sessionStorage.setItem(purchaseKey, 'true');
+    const run = async () => {
+      // Trust an explicit URL status if present (back-compat); otherwise look
+      // the transaction up by id. A bare /gracias visit with no id stays UNKNOWN.
+      let status = urlStatus;
+      if (!status && transactionId) {
+        try {
+          status = await fetchWompiStatus(transactionId, env);
+        } catch (e) {
+          status = 'UNKNOWN';
         }
-        setTrackingFired(true);
-      };
-
-      // Wait for GTM to be ready (500ms delay ensures gtm.load has fired)
-      setTimeout(firePurchaseEvent, 500);
-    }
-
-    // Read customer email (collected in PurchaseModal, saved in localStorage).
-    // After reading, clear the cart-recovery state — the buyer paid, so we
-    // don't need to keep the abandoned-cart envelope hanging around.
-    let customerEmail = null;
-    try {
-      const flat = getFlatSelections();
-      if (flat) {
-        customerEmail = flat.email || null;
       }
-    } catch (e) {
-      // ignore
-    }
-    if (transactionId) {
-      clearCartState();
-    }
+      status = (status || 'UNKNOWN').toUpperCase();
+      if (cancelled) return;
+      setPaymentStatus(status);
 
-    // Handling 1-2d + transit 3-7d => 10d upper bound (safe estimate)
-    const estimated = new Date();
-    estimated.setDate(estimated.getDate() + 10);
-    const estimatedDeliveryDate = estimated.toISOString().slice(0, 10);
+      const isApproved = status === 'APPROVED';
 
-    // Set order data for display
-    setOrderData({
-      orderId: transactionId || null,
-      transactionId: transactionId || null,
-      amount: FIXED_PRICE,
-      customerEmail,
-      estimatedDeliveryDate,
-      formattedAmount: new Intl.NumberFormat('es-CO', {
-        style: 'currency',
-        currency: 'COP',
-        minimumFractionDigits: 0
-      }).format(FIXED_PRICE),
-      date: new Date().toLocaleDateString('es-CO', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
-      })
-    });
+      // Only fire the purchase event + clear the cart on a real, approved
+      // payment. Declined/pending/unknown returns must NOT look like a sale,
+      // and must NOT wipe the cart (the buyer may retry, or abandoned-cart
+      // recovery may still need the envelope).
+      if (isApproved) {
+        const purchaseKey = transactionId ? `purchase_tracked_${transactionId}` : null;
+        const alreadyTracked = purchaseKey ? sessionStorage.getItem(purchaseKey) : false;
+
+        if (!alreadyTracked) {
+          // Wait for GTM to be ready (500ms delay ensures gtm.load has fired)
+          const firePurchaseEvent = () => {
+            const attribution = getAttribution();
+
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({ ecommerce: null });
+            window.dataLayer.push({
+              event: 'purchase',
+              ecommerce: {
+                transaction_id: transactionId || 'direct_visit',
+                value: FIXED_PRICE,
+                currency: 'COP',
+                items: [{
+                  item_id: 'kit_pinta_barriguita',
+                  item_name: 'Kit Pinta Barriguita – Todo Incluido',
+                  price: FIXED_PRICE,
+                  quantity: 1
+                }]
+              },
+              attribution: attribution || undefined
+            });
+            console.log('✓ GA4 Purchase event fired via GTM', { attribution });
+
+            if (purchaseKey) {
+              sessionStorage.setItem(purchaseKey, 'true');
+            }
+            if (!cancelled) setTrackingFired(true);
+          };
+
+          setTimeout(firePurchaseEvent, 500);
+        }
+      }
+
+      // Read customer email (collected in PurchaseModal, saved in localStorage).
+      // Only clear the cart-recovery envelope on an approved payment.
+      let customerEmail = null;
+      try {
+        const flat = getFlatSelections();
+        if (flat) {
+          customerEmail = flat.email || null;
+        }
+      } catch (e) {
+        // ignore
+      }
+      if (isApproved) {
+        clearCartState();
+      }
+
+      // Handling 1-2d + transit 3-7d => 10d upper bound (safe estimate)
+      const estimated = new Date();
+      estimated.setDate(estimated.getDate() + 10);
+      const estimatedDeliveryDate = estimated.toISOString().slice(0, 10);
+
+      if (cancelled) return;
+
+      // Set order data for display
+      setOrderData({
+        orderId: transactionId || null,
+        transactionId: transactionId || null,
+        amount: FIXED_PRICE,
+        customerEmail,
+        estimatedDeliveryDate,
+        formattedAmount: new Intl.NumberFormat('es-CO', {
+          style: 'currency',
+          currency: 'COP',
+          minimumFractionDigits: 0
+        }).format(FIXED_PRICE),
+        date: new Date().toLocaleDateString('es-CO', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric'
+        })
+      });
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
   }, [searchParams]);
 
-  return { orderData, trackingFired };
+  return { orderData, paymentStatus, trackingFired };
 };
 
 export default useOrderTracking;

--- a/src/lib/wompiWidget.js
+++ b/src/lib/wompiWidget.js
@@ -3,11 +3,18 @@
 import { detectInAppBrowser } from './inAppBrowser';
 import { logDiag } from './diag';
 
-const WIDGET_SRC = 'https://checkout.wompi.co/widget.js';
+// Croko routes ALL buyers through Wompi's hosted Web Checkout via a full-page
+// redirect. The embedded JS widget (popup/iframe) was retired because it
+// silently fails to open for a whole class of environments — in-app webviews
+// (Instagram/FB/TikTok), ad-blockers/proxies that block widget.js, slow
+// networks — leaving the buyer on a frozen "Abriendo pasarela…" button with no
+// error and no callback. A top-level navigation cannot be blocked, so it works
+// everywhere. See docs/ads/WOMPI_INAPP_BROWSER_FALLBACK.md for the full
+// history. The return trip lands on /gracias?id=<tx>&env=<env>, where
+// useOrderTracking resolves the real status via Wompi's API and gates the
+// purchase event on APPROVED.
 const WEB_CHECKOUT_URL = 'https://checkout.wompi.co/p/';
-const SCRIPT_TIMEOUT_MS = 12000;
 const SIGNATURE_TIMEOUT_MS = 10000;
-let loaderPromise = null;
 
 const withTimeout = (promise, ms, label) =>
   Promise.race([
@@ -16,42 +23,6 @@ const withTimeout = (promise, ms, label) =>
       setTimeout(() => reject(new Error(`wompi: ${label} timed out (${ms}ms)`)), ms)
     ),
   ]);
-
-const loadWidgetScript = () => {
-  if (typeof window === 'undefined') {
-    return Promise.reject(new Error('wompi: window undefined'));
-  }
-  if (window.WidgetCheckout) return Promise.resolve(window.WidgetCheckout);
-  if (loaderPromise) return loaderPromise;
-
-  loaderPromise = new Promise((resolve, reject) => {
-    const existing = document.querySelector(`script[src="${WIDGET_SRC}"]`);
-    const onLoad = () => {
-      if (window.WidgetCheckout) resolve(window.WidgetCheckout);
-      else reject(new Error('wompi: WidgetCheckout not exposed after load'));
-    };
-    const onError = () => reject(new Error('wompi: failed to load widget.js'));
-
-    if (existing) {
-      existing.addEventListener('load', onLoad, { once: true });
-      existing.addEventListener('error', onError, { once: true });
-      return;
-    }
-    const script = document.createElement('script');
-    script.src = WIDGET_SRC;
-    script.async = true;
-    script.addEventListener('load', onLoad, { once: true });
-    script.addEventListener('error', onError, { once: true });
-    document.head.appendChild(script);
-  }).catch((err) => {
-    // Reset so a retry can re-attempt the load instead of reusing a
-    // permanently-rejected promise.
-    loaderPromise = null;
-    throw err;
-  });
-
-  return loaderPromise;
-};
 
 const fetchSignature = async ({ reference, amountInCents, currency }) => {
   const controller = new AbortController();
@@ -79,7 +50,8 @@ const fetchSignature = async ({ reference, amountInCents, currency }) => {
 
 // Full-page redirect to Wompi's hosted Web Checkout. This is a top-level
 // navigation (no popup, no cross-origin iframe), so it works inside Instagram /
-// Facebook / TikTok in-app webviews where the JS widget silently fails.
+// Facebook / TikTok in-app webviews where the JS widget silently fails — and in
+// every normal browser too.
 const redirectToWebCheckout = ({
   orderId,
   amountInCents,
@@ -116,11 +88,12 @@ export const openWompiCheckout = async ({
   currency = 'COP',
   email,
   fullName,
-  onResult,
 }) => {
   const publicKey = process.env.NEXT_PUBLIC_WOMPI_PUBLIC_KEY;
   if (!publicKey) throw new Error('wompi: NEXT_PUBLIC_WOMPI_PUBLIC_KEY missing');
 
+  // isInApp is no longer a branch (everyone redirects) but we still log it so
+  // the diag stream keeps showing the environment mix of paying users.
   const { isInApp, app } = detectInAppBrowser();
   logDiag('wompi_checkout_start', { orderId, isInApp, app });
 
@@ -134,83 +107,22 @@ export const openWompiCheckout = async ({
     );
     logDiag('wompi_signature_ok', { orderId, ms: Date.now() - t0 });
   } catch (err) {
+    // The only legitimate dead-end: without a valid signature Wompi rejects the
+    // transaction anyway. Fails loudly in ≤10s so the button shows an error
+    // instead of hanging.
     logDiag('wompi_signature_fail', { orderId, error: err?.message });
     throw err;
   }
 
-  // In-app webviews: skip the popup/iframe widget entirely and hand off via
-  // a full-page redirect. The page navigates away, so onResult never fires
-  // here — the return trip lands on /gracias and useOrderTracking takes over.
-  if (isInApp) {
-    redirectToWebCheckout({
-      orderId,
-      amountInCents,
-      currency,
-      email,
-      fullName,
-      signature,
-      publicKey,
-    });
-    return;
-  }
-
-  let WidgetCheckout;
-  const tScript = Date.now();
-  try {
-    WidgetCheckout = await withTimeout(
-      loadWidgetScript(),
-      SCRIPT_TIMEOUT_MS,
-      'widget.js load'
-    );
-    logDiag('wompi_script_ok', { orderId, ms: Date.now() - tScript });
-  } catch (err) {
-    logDiag('wompi_script_fail', { orderId, error: err?.message });
-    // Script blocked but signature is valid → degrade gracefully to the
-    // hosted redirect instead of dead-ending the user.
-    redirectToWebCheckout({
-      orderId,
-      amountInCents,
-      currency,
-      email,
-      fullName,
-      signature,
-      publicKey,
-    });
-    return;
-  }
-
-  // Wompi's WAF rejects http://localhost redirect URLs. Skip redirectUrl in dev;
-  // the JS callback still fires with the transaction result.
-  const isLocalhost = /^(localhost|127\.0\.0\.1)$/i.test(window.location.hostname);
-  const config = {
-    currency,
+  // Single path for everyone: hand off via a top-level navigation. The page
+  // navigates away here; the outcome is read on return at /gracias.
+  redirectToWebCheckout({
+    orderId,
     amountInCents,
-    reference: orderId,
+    currency,
+    email,
+    fullName,
+    signature,
     publicKey,
-    signature: { integrity: signature },
-    collectShipping: 'true',
-    collectCustomerLegalId: 'true',
-    customerData: {
-      email,
-      fullName,
-    },
-  };
-  if (!isLocalhost) {
-    config.redirectUrl = `${window.location.origin}/gracias`;
-  }
-
-  try {
-    const checkout = new WidgetCheckout(config);
-    logDiag('wompi_widget_open_called', { orderId });
-    checkout.open((result) => {
-      logDiag('wompi_widget_result', {
-        orderId,
-        status: result?.transaction?.status || 'none',
-      });
-      if (typeof onResult === 'function') onResult(result);
-    });
-  } catch (err) {
-    logDiag('wompi_widget_open_throw', { orderId, error: err?.message });
-    throw err;
-  }
+  });
 };


### PR DESCRIPTION
…eal status

Multiple buyers reported the embedded Wompi widget modal never opening, leaving them on a frozen "Abriendo pasarela..." button with no way to pay. The JS widget renders a cross-origin popup/iframe that is silently blocked by in-app webviews, ad-blockers, proxies, and slow networks. A top-level navigation cannot be blocked, so make the hosted Web Checkout redirect the single path for everyone (it was already built and battle-tested as the in-app fallback).

- wompiWidget.js: retire the JS-widget branch; every buyer redirects to checkout.wompi.co/p/ after the signature fetch. Diag still logs isInApp.
- useOrderTracking.js: the hosted redirect returns only ?id=<tx>&env=, no status, so resolve the real outcome via Wompi's public transaction API and only fire the GA4 purchase event + clear the cart when status is APPROVED. Previously any return with an id looked like a sale (a declined card would show a false confirmation and inflate purchases).
- gracias/page.js + PaymentIssueBanner.js: branch the UI on resolved status — APPROVED keeps the confirmation; PENDING shows a "confirming" message; declined/error shows a no-charge retry CTA back to ?cart= recovery.

Attribution unchanged: begin_checkout webhook + dataLayer fire before handoff, reference = order_id, and the Wompi->n8n APPROVED webhook stays authoritative.