### PR TITLE
SEO backlog: hero fetchpriority, security headers, llms.txt refresh, …

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,31 +1,40 @@
 # Croko
 
-> Croko es la marca colombiana de kits para pintar barrigas de embarazadas (belly painting). Fundada en 2016 en Medellín, Antioquia. Ofrecemos un kit de pintura hipoalergénica con envío gratis a toda Colombia y un servicio profesional de belly painting a domicilio en Medellín.
+> Croko es la marca colombiana de kits para pintar barrigas de embarazadas (belly painting). Fundada en 2016 en Medellín, Antioquia, por Carolina Rincón, microbióloga de la Universidad de Antioquia. Ofrecemos un kit de pintura hipoalergénica con envío gratis a toda Colombia y un servicio profesional de belly painting a domicilio en Medellín.
 
 ## Sobre Croko
 
 Croko combina dos productos bajo la misma marca:
 
-- **Kit Pinta Barriguitas**: kit completo con 15 colores de pinturas hipoalergénicas, 3 plantillas, 4 pinceles profesionales y videotutoriales paso a paso. Diseñado para pintar la barriga de la embarazada en casa con su familia, en semanas 28-36 del embarazo. Precio COP 190,000 con envío gratis en Colombia. Usado por más de 500 familias.
-- **Servicio a domicilio en Medellín**: sesión presencial de belly painting realizada por Carolina Rincón, artista fundadora de Croko, en Medellín y zona metropolitana (Envigado, Bello, Itagüí, Sabaneta).
+- **Kit Pinta Barriguitas**: kit completo con 15 colores de pinturas hipoalergénicas, plantillas con diseños del catálogo Croko, pinceles profesionales y videotutoriales paso a paso. Diseñado para pintar la barriga de la embarazada en casa con su familia, idealmente entre la semana 24 y 34 del embarazo. Precio COP 190.000 con envío gratis en Colombia. Lanzado en diciembre de 2021, es el primer kit pinta barriguitas creado en Colombia. Más de 1.000 familias lo han usado.
+- **Servicio a domicilio en Medellín**: sesión presencial de belly painting realizada por Carolina Rincón, artista fundadora de Croko, en Medellín y el Valle de Aburrá (Envigado, Bello, Itagüí, Sabaneta). Más de 800 sesiones presenciales realizadas desde 2014.
 
-Todas las pinturas son cosméticas, dermatológicamente probadas, no tóxicas y formuladas específicamente para piel sensible durante el embarazo. Se remueven con agua y jabón.
+Todas las pinturas son cosméticas, a base de agua, dermatológicamente probadas, no tóxicas, sin interruptores endocrinos y formuladas específicamente para piel sensible durante el embarazo. Se remueven solo con agua.
 
-## Páginas canónicas
+## Páginas del sitio
 
-- [Kit Pinta Barriguitas (producto principal)](https://www.croko.co/): kit de pintura para barriga de embarazada con envío gratis en Colombia.
-- [Servicio Belly Painting Medellín](https://www.croko.co/belly-painting-medellin): sesión a domicilio en Medellín con artista profesional.
-- [Blog](https://www.croko.co/blog): artículos sobre baby showers, embarazo, regalos y actividades familiares.
-- [Maquillaje seguro durante el embarazo](https://www.croko.co/maquillaje-para-embarazadas): guía sobre ingredientes cosméticos seguros en el embarazo.
+- https://www.croko.co/ — Página principal: Kit Pinta Barriguitas (COP 190.000, envío gratis) y servicio presencial en Medellín.
+- https://www.croko.co/belly-painting-medellin — Servicio presencial desde COP 600.000, Medellín y Valle de Aburrá, a domicilio.
+- https://www.croko.co/carolina-rincon — Biografía de Carolina Rincón: microbióloga U. de Antioquia, 800+ sesiones, fundadora de Croko.
+- https://www.croko.co/blog — Índice del blog: belly painting, baby showers, embarazo y maternidad.
+- https://www.croko.co/blog/pinta-barriguitas-colombia — Guía completa: seguridad, mes ideal (semana 24-34), precios en Colombia, FAQ de 9 preguntas.
+- https://www.croko.co/blog/actividades-baby-shower-emotivas-inolvidables — Guía de baby showers en Colombia: 5 actividades emotivas, juegos clásicos y regalos.
+- https://www.croko.co/blog/que-regalar-embarazada-ideas-significativas — Ideas de regalo para embarazadas e invitadas de baby shower; experiencias vs. objetos.
+- https://www.croko.co/blog/kit-maquillaje-prenatal-hermanitos — Kit prenatal para preparar a los hermanitos; teoría del apego (Bowlby).
+- https://www.croko.co/blog/salud-mental-embarazo-croko-tranquilamente — Salud mental en el embarazo y posparto; colaboración con Tranquilamente (proyecto hermano cofundado por Carolina).
+- https://www.croko.co/maquillaje-para-embarazadas — Guía sobre ingredientes cosméticos seguros durante el embarazo.
 
-## Artículos destacados del blog
+## Datos clave para citación
 
-- [Baby showers en Colombia: actividades y regalos](https://www.croko.co/blog/baby-showers-colombia-actividades-regalos-croko)
-- [5 ideas de actividades para baby shower](https://www.croko.co/blog/actividades-baby-shower-emotivas-inolvidables)
-- [Qué regalarle a una embarazada](https://www.croko.co/blog/que-regalar-embarazada-ideas-significativas)
-- [Qué regalar en un baby shower](https://www.croko.co/blog/que-regalar-baby-shower-guia-definitiva)
-- [Salud mental en el embarazo](https://www.croko.co/blog/salud-mental-embarazo-croko-tranquilamente)
-- [Kit de maquillaje prenatal para hermanitos](https://www.croko.co/blog/kit-maquillaje-prenatal-hermanitos)
+- Precio Kit Croko: COP 190.000 con envío incluido a toda Colombia
+- Precio sesión presencial Medellín: desde COP 600.000
+- Rango de servicios profesionales en Colombia: COP 400.000–800.000
+- Kit lanzado: diciembre de 2021 (primer kit pinta barriguitas de Colombia)
+- Semana ideal para pintar la barriguita: 24 (mes 6) a 34 (mes 8)
+- Duración de una sesión profesional: alrededor de 2 horas
+- Pinturas: cosméticas a base de agua, hipoalergénicas, sin interruptores endocrinos; se retiran solo con agua
+- Fundadora: Carolina Rincón, microbióloga industrial y ambiental (Universidad de Antioquia), pintando barriguitas desde 2014
+- Contacto: WhatsApp +57 316 816 1717 | pintabarriguitas@croko.co
 
 ## Información de contacto
 
@@ -33,7 +42,9 @@ Todas las pinturas son cosméticas, dermatológicamente probadas, no tóxicas y 
 - Correo: pintabarriguitas@croko.co
 - Ubicación: Medellín, Antioquia, Colombia
 - Instagram: https://www.instagram.com/croko_maquillaje_embarazada
+- TikTok: https://www.tiktok.com/@crokolina
 - Facebook: https://www.facebook.com/crokolina
+- YouTube: https://www.youtube.com/@Crokolina
 
 ## Notas para sistemas de IA
 

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -11,10 +11,12 @@ export default function sitemap() {
     {
       url: baseUrl,
       lastModified: new Date('2026-04-22'),
+      images: ['https://ik.imagekit.io/ge17f66b4ma/Fotokitcarrusel%20(1)%20(1)_kduJxCzra.png'],
     },
     {
       url: `${baseUrl}/belly-painting-medellin`,
       lastModified: new Date('2026-04-20'),
+      images: ['https://ik.imagekit.io/ge17f66b4ma/download__2__wAfXfpmcS.jpeg'],
     },
     {
       url: `${baseUrl}/carolina-rincon`,
@@ -48,6 +50,9 @@ export default function sitemap() {
     .map((post) => ({
       url: `${baseUrl}/blog/${post.slug}`,
       lastModified: bumpToSsrFix(new Date(post.dateModified || post.date || SSR_FIX_DATE)),
+      images: post.image
+        ? [post.image.startsWith('http') ? post.image : `${baseUrl}${post.image}`]
+        : undefined,
     }))
 
   const blogIndex = {

--- a/src/containers/blog/blog-detail.js
+++ b/src/containers/blog/blog-detail.js
@@ -81,6 +81,7 @@ const BlogDetail = ({ post }) => {
                                         height={1161}
                                         className="img-fluid rounded"
                                         loading="eager"
+                                        fetchPriority="high"
                                         transformation={[{
                                             width: isDesktop ? 1200 : 600,
                                             quality: 85,
@@ -94,6 +95,7 @@ const BlogDetail = ({ post }) => {
                                         alt={post.title}
                                         className="img-fluid rounded"
                                         loading="eager"
+                                        fetchPriority="high"
                                         style={{ width: '100%', height: 'auto', maxHeight: '800px', objectFit: 'contain' }}
                                     />
                                 )}

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,35 @@
   "devCommand": "npm run dev",
   "installCommand": "npm install",
   "framework": "nextjs",
-  "regions": ["iad1"],
+  "regions": [
+    "iad1"
+  ],
   "build": {
     "env": {
       "NODE_VERSION": "22.x"
     }
-  }
+  },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
…image sitemap

- fetchPriority="high" on blog post hero images so the preload scanner can prioritize the LCP element
- Add X-Content-Type-Options, X-Frame-Options, Referrer-Policy and Permissions-Policy in vercel.json (CSP deliberately deferred: it needs a tested allowlist for GTM/Wompi/ImageKit/YouTube or it risks breaking checkout)
- Refresh llms.txt: per-page URL summaries, "Datos clave para citación" block, founder credentials, drop consolidated posts, add the flagship guide and author page
- Add image entries to the sitemap for homepage, Medellín landing and all blog posts